### PR TITLE
feat: Support analyzer v7.x alongside v8.x for broader compatibility

### DIFF
--- a/packages/isar_plus/pubspec.yaml
+++ b/packages/isar_plus/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
-  analyzer: ^8.1.1 
+  analyzer: ">=7.0.0 <9.0.0"
   build: ^3.0.0
   ffi: ">=2.0.0 <3.0.0"
   js: any


### PR DESCRIPTION
## 🎯 What does this PR do?

Updates the `analyzer` dependency constraint to support both v7.x and v8.x versions, resolving compatibility issues with other packages that still use analyzer v7.

## 🐛 Problem

- Users reported dependency conflicts when trying to use isar_plus with other packages
- Current constraint `^8.1.1` only supported analyzer v8.1.1+
- Many packages in the ecosystem still use analyzer v7.x
- This created incompatible dependency constraints preventing package usage

## ✅ Solution

Changed analyzer dependency constraint from:
```yaml
analyzer: ^8.1.1

