### PR TITLE
feat: add key field to watcher system for data identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ local.properties
 *.info
 *.profraw
 *.json
+
+packages/hive_plus

--- a/packages/isar_core/src/core/watcher.rs
+++ b/packages/isar_core/src/core/watcher.rs
@@ -29,8 +29,9 @@ pub struct ChangeDetail {
     pub change_type: ChangeType,
     pub collection_name: String,
     pub object_id: i64,
+    pub key: String, 
     pub field_changes: Vec<FieldChange>,
-    pub full_document: Option<String>, // JSON representation of the full document after change
+    pub full_document: Option<String>,
 }
 
 struct Watcher {

--- a/packages/isar_plus/lib/src/watcher_details.dart
+++ b/packages/isar_plus/lib/src/watcher_details.dart
@@ -226,6 +226,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   ///
   /// [collectionName] identifies the data collection (table, index, etc.).
   /// [objectId] is the unique identifier within that collection.
+  /// [key] is the unique identifier for this data object.
   /// [changeType] specifies the nature of the modification.
   /// [fieldChanges] contains the individual field modifications.
   /// [fullDocument] optionally holds the complete post-change state.
@@ -233,6 +234,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   const ChangeDetail({
     required this.collectionName,
     required this.objectId,
+    required this.key,
     required this.changeType,
     required this.fieldChanges,
     this.fullDocument,
@@ -255,6 +257,11 @@ class ChangeDetail<T extends DocumentSerializable> {
       final objectId = json['object_id'];
       if (objectId is! int) {
         throw const FormatException('object_id must be an integer');
+      }
+
+      final key = json['key'];
+      if (key is! String || key.isEmpty) {
+        throw const FormatException('key must be a non-empty string');
       }
 
       final changeTypeStr = json['change_type'];
@@ -297,6 +304,7 @@ class ChangeDetail<T extends DocumentSerializable> {
       return ChangeDetail<T>(
         collectionName: collectionName,
         objectId: objectId,
+        key: key,
         changeType: changeType,
         fieldChanges: fieldChanges,
         fullDocument: fullDocument,
@@ -315,6 +323,10 @@ class ChangeDetail<T extends DocumentSerializable> {
 
   /// The unique identifier of the changed object within its collection.
   final int objectId;
+
+  /// Unique identifier for this data object,
+  /// typically the primary key.
+  final String key;
 
   /// The type of database operation that was performed.
   final ChangeType changeType;
@@ -360,6 +372,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   Map<String, dynamic> toJson() => {
     'collection_name': collectionName,
     'object_id': objectId,
+    'key': key,
     'change_type': changeType.value,
     'timestamp': timestamp?.toIso8601String(),
     'full_document': fullDocument?.toJson(),
@@ -370,6 +383,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   ChangeDetail<T> copyWith({
     String? collectionName,
     int? objectId,
+    String? key,
     ChangeType? changeType,
     DateTime? timestamp,
     T? fullDocument,
@@ -377,6 +391,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   }) => ChangeDetail<T>(
     collectionName: collectionName ?? this.collectionName,
     objectId: objectId ?? this.objectId,
+    key: key ?? this.key,
     changeType: changeType ?? this.changeType,
     timestamp: timestamp ?? this.timestamp,
     fullDocument: fullDocument ?? this.fullDocument,
@@ -391,6 +406,7 @@ class ChangeDetail<T extends DocumentSerializable> {
           ..write('ChangeDetail<$T>(')
           ..write('collection: $collectionName, ')
           ..write('id: $objectId, ')
+          ..write('key: $key, ')
           ..write('type: $changeType, ')
           ..write('timestamp: ${timestamp?.toIso8601String()}, ')
           ..write('fieldChanges: ${fieldChanges.length}')
@@ -405,6 +421,7 @@ class ChangeDetail<T extends DocumentSerializable> {
       other is ChangeDetail<T> &&
           collectionName == other.collectionName &&
           objectId == other.objectId &&
+          key == other.key &&
           changeType == other.changeType &&
           timestamp == other.timestamp &&
           fullDocument == other.fullDocument &&
@@ -414,6 +431,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   int get hashCode => Object.hash(
     collectionName,
     objectId,
+    key,
     changeType,
     timestamp,
     fullDocument,


### PR DESCRIPTION
- Add key field to Rust ChangeDetail struct for proper data object identification
- Update change detector to extract key from Frame objects (index 2) and JSON objects
- Enhance Dart ChangeDetail class with key field support in serialization/deserialization
- Improve change tracking by including unique identifiers from hive_plus Frame structure
- Enable better debugging and data tracking in watcher notifications