### PR TITLE
refactor: Make fullDocument non-nullable with direct serialization

### DIFF
--- a/packages/isar_core/src/core/watcher.rs
+++ b/packages/isar_core/src/core/watcher.rs
@@ -31,7 +31,7 @@ pub struct ChangeDetail {
     pub object_id: i64,
     pub key: String, 
     pub field_changes: Vec<FieldChange>,
-    pub full_document: Option<String>,
+    pub full_document: String,
 }
 
 struct Watcher {

--- a/packages/isar_plus/lib/src/isar_collection.dart
+++ b/packages/isar_plus/lib/src/isar_collection.dart
@@ -146,10 +146,8 @@ abstract class IsarCollection<ID, OBJ> {
   /// }
   ///
   /// collection.watchDetailed<User>().listen((change) {
-  ///   if (change.fullDocument != null) {
-  ///     print('User name: ${change.fullDocument!.name}');
-  ///     print('User age: ${change.fullDocument!.age}');
-  ///   }
+  ///   print('User name: ${change.fullDocument.name}');
+  ///   print('User age: ${change.fullDocument.age}');
   /// });
   /// ```
   ///

--- a/packages/isar_plus/lib/src/watcher_details.dart
+++ b/packages/isar_plus/lib/src/watcher_details.dart
@@ -229,7 +229,7 @@ class ChangeDetail<T extends DocumentSerializable> {
   /// [key] is the unique identifier for this data object.
   /// [changeType] specifies the nature of the modification.
   /// [fieldChanges] contains the individual field modifications.
-  /// [fullDocument] optionally holds the complete post-change state.
+  /// [fullDocument] holds the complete post-change state.
   /// [timestamp] records when the change occurred (defaults to current time).
   const ChangeDetail({
     required this.collectionName,
@@ -237,7 +237,7 @@ class ChangeDetail<T extends DocumentSerializable> {
     required this.key,
     required this.changeType,
     required this.fieldChanges,
-    this.fullDocument,
+    required this.fullDocument,
     this.timestamp,
   }) : assert(collectionName != '', 'Collection name cannot be empty');
 
@@ -280,7 +280,7 @@ class ChangeDetail<T extends DocumentSerializable> {
           )
           .toList(growable: false);
 
-      T? fullDocument;
+      T fullDocument;
       final fullDocumentJson = json['full_document'];
       if (fullDocumentJson != null && documentParser != null) {
         if (fullDocumentJson is Map<String, dynamic>) {
@@ -293,6 +293,10 @@ class ChangeDetail<T extends DocumentSerializable> {
             'full_document must be a Map<String, dynamic> or JSON string',
           );
         }
+      } else {
+        throw const FormatException(
+          'full_document is required and documentParser must be provided',
+        );
       }
 
       DateTime? timestamp;
@@ -336,9 +340,8 @@ class ChangeDetail<T extends DocumentSerializable> {
 
   /// The complete document state after the change was applied.
   ///
-  /// This is optional and may be null if full document tracking is disabled
-  /// or if the document was deleted.
-  final T? fullDocument;
+  /// This contains the full document data and is guaranteed to be present.
+  final T fullDocument;
 
   /// Individual field-level changes within this object.
   ///
@@ -375,7 +378,7 @@ class ChangeDetail<T extends DocumentSerializable> {
     'key': key,
     'change_type': changeType.value,
     'timestamp': timestamp?.toIso8601String(),
-    'full_document': fullDocument?.toJson(),
+    'full_document': fullDocument.toJson(),
     'field_changes': fieldChanges.map((fc) => fc.toJson()).toList(),
   };
 


### PR DESCRIPTION
• Convert ChangeDetail.fullDocument from T? to T (non-nullable) • Replace complex manual JSON construction with reader.serialize() • Ensure delete operations return old object data instead of null • Add panic! for empty/null data to guarantee non-nullable contract • Remove unused HashMap import and simplify return types • Update Dart documentation examples to reflect non-nullable fullDocument • Optimize serialization using built-in IsarReader methods for better performance

This ensures fullDocument is always guaranteed to contain valid object data across all change types (insert/update/delete) with improved error handling.