### PR TITLE
Fix generator for embedded schemas and bump isar_plus to 1.0.24

### DIFF
--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -24,6 +24,11 @@ final CountSchema = IsarGeneratedSchema(
         name: 'step',
         type: IsarType.long,
       ),
+      IsarPropertySchema(
+        name: 'metadata',
+        type: IsarType.object,
+        target: 'StepMetadata',
+      ),
     ],
     indexes: [],
   ),
@@ -32,12 +37,18 @@ final CountSchema = IsarGeneratedSchema(
     deserialize: deserializeCount,
     deserializeProperty: deserializeCountProp,
   ),
-  getEmbeddedSchemas: () => [],
+  getEmbeddedSchemas: () => [StepMetadataSchema],
 );
 
 @isarProtected
 int serializeCount(IsarWriter writer, Count object) {
   IsarCore.writeLong(writer, 1, object.step);
+  {
+    final value = object.metadata;
+    final objectWriter = IsarCore.beginObject(writer, 2);
+    serializeStepMetadata(objectWriter, value);
+    IsarCore.endObject(writer, objectWriter);
+  }
   return object.id;
 }
 
@@ -47,9 +58,24 @@ Count deserializeCount(IsarReader reader) {
   _id = IsarCore.readId(reader);
   final int _step;
   _step = IsarCore.readLong(reader, 1);
+  final StepMetadata _metadata;
+  {
+    final objectReader = IsarCore.readObject(reader, 2);
+    if (objectReader.isNull) {
+      _metadata = StepMetadata(
+        recordedAt:
+            DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal(),
+      );
+    } else {
+      final embedded = deserializeStepMetadata(objectReader);
+      IsarCore.freeReader(objectReader);
+      _metadata = embedded;
+    }
+  }
   final object = Count(
     _id,
     _step,
+    _metadata,
   );
   return object;
 }
@@ -61,6 +87,20 @@ dynamic deserializeCountProp(IsarReader reader, int property) {
       return IsarCore.readId(reader);
     case 1:
       return IsarCore.readLong(reader, 1);
+    case 2:
+      {
+        final objectReader = IsarCore.readObject(reader, 2);
+        if (objectReader.isNull) {
+          return StepMetadata(
+            recordedAt:
+                DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal(),
+          );
+        } else {
+          final embedded = deserializeStepMetadata(objectReader);
+          IsarCore.freeReader(objectReader);
+          return embedded;
+        }
+      }
     default:
       throw ArgumentError('Unknown property: $property');
   }
@@ -339,7 +379,14 @@ extension CountQueryFilter on QueryBuilder<Count, Count, QFilterCondition> {
   }
 }
 
-extension CountQueryObject on QueryBuilder<Count, Count, QFilterCondition> {}
+extension CountQueryObject on QueryBuilder<Count, Count, QFilterCondition> {
+  QueryBuilder<Count, Count, QAfterFilterCondition> metadata(
+      FilterQuery<StepMetadata> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, 2);
+    });
+  }
+}
 
 extension CountQuerySortBy on QueryBuilder<Count, Count, QSortBy> {
   QueryBuilder<Count, Count, QAfterSortBy> sortById() {
@@ -413,6 +460,12 @@ extension CountQueryProperty1 on QueryBuilder<Count, Count, QProperty> {
       return query.addProperty(1);
     });
   }
+
+  QueryBuilder<Count, StepMetadata, QAfterProperty> metadataProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addProperty(2);
+    });
+  }
 }
 
 extension CountQueryProperty2<R> on QueryBuilder<Count, R, QAfterProperty> {
@@ -425,6 +478,12 @@ extension CountQueryProperty2<R> on QueryBuilder<Count, R, QAfterProperty> {
   QueryBuilder<Count, (R, int), QAfterProperty> stepProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addProperty(1);
+    });
+  }
+
+  QueryBuilder<Count, (R, StepMetadata), QAfterProperty> metadataProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addProperty(2);
     });
   }
 }
@@ -442,4 +501,340 @@ extension CountQueryProperty3<R1, R2>
       return query.addProperty(1);
     });
   }
+
+  QueryBuilder<Count, (R1, R2, StepMetadata), QOperations> metadataProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addProperty(2);
+    });
+  }
 }
+
+// **************************************************************************
+// _IsarEmbeddedGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, invalid_use_of_protected_member, lines_longer_than_80_chars, constant_identifier_names, avoid_js_rounded_ints, no_leading_underscores_for_local_identifiers, require_trailing_commas, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_in_if_null_operators, library_private_types_in_public_api, prefer_const_constructors
+// ignore_for_file: type=lint
+
+final StepMetadataSchema = IsarGeneratedSchema(
+  schema: IsarSchema(
+    name: 'StepMetadata',
+    embedded: true,
+    properties: [
+      IsarPropertySchema(
+        name: 'recordedAt',
+        type: IsarType.dateTime,
+      ),
+      IsarPropertySchema(
+        name: 'note',
+        type: IsarType.string,
+      ),
+    ],
+    indexes: [],
+  ),
+  converter: IsarObjectConverter<void, StepMetadata>(
+    serialize: serializeStepMetadata,
+    deserialize: deserializeStepMetadata,
+  ),
+);
+
+@isarProtected
+int serializeStepMetadata(IsarWriter writer, StepMetadata object) {
+  IsarCore.writeLong(
+      writer, 1, object.recordedAt.toUtc().microsecondsSinceEpoch);
+  IsarCore.writeString(writer, 2, object.note);
+  return 0;
+}
+
+@isarProtected
+StepMetadata deserializeStepMetadata(IsarReader reader) {
+  final DateTime _recordedAt;
+  {
+    final value = IsarCore.readLong(reader, 1);
+    if (value == -9223372036854775808) {
+      _recordedAt =
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal();
+    } else {
+      _recordedAt =
+          DateTime.fromMicrosecondsSinceEpoch(value, isUtc: true).toLocal();
+    }
+  }
+  final String _note;
+  _note = IsarCore.readString(reader, 2) ?? '';
+  final object = StepMetadata(
+    recordedAt: _recordedAt,
+    note: _note,
+  );
+  return object;
+}
+
+extension StepMetadataQueryFilter
+    on QueryBuilder<StepMetadata, StepMetadata, QFilterCondition> {
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtEqualTo(
+    DateTime value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        EqualCondition(
+          property: 1,
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtGreaterThan(
+    DateTime value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        GreaterCondition(
+          property: 1,
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtGreaterThanOrEqualTo(
+    DateTime value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        GreaterOrEqualCondition(
+          property: 1,
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtLessThan(
+    DateTime value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        LessCondition(
+          property: 1,
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtLessThanOrEqualTo(
+    DateTime value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        LessOrEqualCondition(
+          property: 1,
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      recordedAtBetween(
+    DateTime lower,
+    DateTime upper,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        BetweenCondition(
+          property: 1,
+          lower: lower,
+          upper: upper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        EqualCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteGreaterThan(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        GreaterCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteGreaterThanOrEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        GreaterOrEqualCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteLessThan(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        LessCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteLessThanOrEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        LessOrEqualCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteBetween(
+    String lower,
+    String upper, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        BetweenCondition(
+          property: 2,
+          lower: lower,
+          upper: upper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        StartsWithCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        EndsWithCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        ContainsCondition(
+          property: 2,
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition> noteMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        MatchesCondition(
+          property: 2,
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const EqualCondition(
+          property: 2,
+          value: '',
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<StepMetadata, StepMetadata, QAfterFilterCondition>
+      noteIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const GreaterCondition(
+          property: 2,
+          value: '',
+        ),
+      );
+    });
+  }
+}
+
+extension StepMetadataQueryObject
+    on QueryBuilder<StepMetadata, StepMetadata, QFilterCondition> {}

--- a/packages/isar_plus/lib/src/generator/code_gen/collection_schema_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/collection_schema_generator.dart
@@ -21,6 +21,9 @@ String _generateSchema(ObjectInfo object) {
     ),''';
   }
 
+  final embeddedSchemas = object.embeddedDartNames
+      .map((e) => '${e.capitalize()}Schema')
+      .join(',');
   final properties =
       object.properties
           .where((e) => !e.isId || e.type != IsarType.long)
@@ -41,6 +44,6 @@ String _generateSchema(ObjectInfo object) {
         deserialize: deserialize${object.dartName},
         ${!object.isEmbedded ? 'deserializeProperty: deserialize${object.dartName}Prop,' : ''}
       ),
-      ${object.isEmbedded ? '' : 'getEmbeddedSchemas: () => [],'}
+      ${object.isEmbedded ? '' : 'getEmbeddedSchemas: () => [$embeddedSchemas],'}
     );''';
 }


### PR DESCRIPTION
This pull request adds support for embedded objects to the Isar database schema and updates the counter example app to store and display metadata for each count step. The main changes include introducing a new `StepMetadata` embedded class, updating the data model and UI to use it, and generating code for embedded schemas and queries.

- fix the generator so embedded schemas are registered via `getEmbeddedSchemas`
- add an embedded model to the counter example to cover the runtime scenario

issue #30 


