### PR TITLE
feat: Add deleteDatabase API for encrypted database cleanup

### DIFF
--- a/packages/isar_core/src/native/mod.rs
+++ b/packages/isar_core/src/native/mod.rs
@@ -4,6 +4,7 @@ mod isar_serializer;
 mod mdbx;
 mod native_collection;
 mod native_cursor;
+pub mod native_delete;
 mod native_index;
 mod native_insert;
 pub mod native_instance;

--- a/packages/isar_core/src/native/native_delete.rs
+++ b/packages/isar_core/src/native/native_delete.rs
@@ -1,0 +1,16 @@
+use super::native_open::get_isar_path;
+use crate::core::error::Result;
+use std::fs::remove_file;
+
+pub fn delete_database_files(name: &str, dir: &str) -> Result<()> {
+    let path = get_isar_path(name, dir);
+    
+    // Remove main database file
+    let _ = remove_file(&path);
+    
+    // Remove lock file
+    let lock_path = format!("{}.lock", path);
+    let _ = remove_file(&lock_path);
+    
+    Ok(())
+}

--- a/packages/isar_core/src/sqlite/mod.rs
+++ b/packages/isar_core/src/sqlite/mod.rs
@@ -3,6 +3,7 @@ mod sql;
 mod sqlite3;
 mod sqlite_collection;
 mod sqlite_cursor;
+pub mod sqlite_delete;
 mod sqlite_insert;
 pub mod sqlite_instance;
 mod sqlite_open;

--- a/packages/isar_core/src/sqlite/sqlite_delete.rs
+++ b/packages/isar_core/src/sqlite/sqlite_delete.rs
@@ -1,0 +1,26 @@
+use crate::core::error::Result;
+use crate::SQLITE_MEMORY_DIR;
+use std::fs::remove_file;
+use std::path::PathBuf;
+
+pub fn delete_database_files(name: &str, dir: &str) -> Result<()> {
+    if dir == SQLITE_MEMORY_DIR {
+        // Memory databases don't have files to delete
+        return Ok(());
+    }
+    
+    let mut path_buf = PathBuf::from(dir);
+    path_buf.push(format!("{}.sqlite", name));
+    let path = path_buf.to_string_lossy().to_string();
+    
+    // Remove main database file
+    let _ = remove_file(&path_buf);
+    
+    // Remove WAL file
+    let _ = remove_file(&format!("{}-wal", path));
+    
+    // Remove SHM file  
+    let _ = remove_file(&format!("{}-shm", path));
+    
+    Ok(())
+}

--- a/packages/isar_plus/lib/src/impl/bindings.dart
+++ b/packages/isar_plus/lib/src/impl/bindings.dart
@@ -938,6 +938,25 @@ class IsarCoreBindings {
       _isar_closePtr
           .asFunction<bool Function(ffi.Pointer<CIsarInstance>, bool)>();
 
+  int isar_delete_database(
+    ffi.Pointer<CString> name,
+    ffi.Pointer<CString> path,
+    bool sqlite,
+  ) {
+    return _isar_delete_database(name, path, sqlite);
+  }
+
+  late final _isar_delete_databasePtr = _lookup<
+    ffi.NativeFunction<
+      ffi.Uint8 Function(ffi.Pointer<CString>, ffi.Pointer<CString>, ffi.Bool)
+    >
+  >('isar_delete_database');
+  late final _isar_delete_database =
+      _isar_delete_databasePtr
+          .asFunction<
+            int Function(ffi.Pointer<CString>, ffi.Pointer<CString>, bool)
+          >();
+
   int isar_query_new(
     ffi.Pointer<CIsarInstance> isar,
     int collection_index,

--- a/packages/isar_plus/lib/src/isar.dart
+++ b/packages/isar_plus/lib/src/isar.dart
@@ -288,4 +288,29 @@ abstract class Isar {
   static int fastHash(String string) {
     return platformFastHash(string);
   }
+
+  /// Delete a database without opening it first.
+  ///
+  /// This is useful when you need to delete a corrupted or encrypted database
+  /// that cannot be opened with the current encryption key.
+  ///
+  /// [name] is the name of the database instance.
+  /// [directory] is the directory where the database files are stored.
+  /// [engine] specifies whether it's an Isar or SQLite database.
+  static void deleteDatabase({
+    required String name,
+    required String directory,
+    IsarEngine engine = IsarEngine.isar,
+  }) {
+    final namePtr = IsarCore._toNativeString(name);
+    final directoryPtr = IsarCore._toNativeString(directory);
+
+    IsarCore.b
+        .isar_delete_database(
+          namePtr,
+          directoryPtr,
+          engine == IsarEngine.sqlite,
+        )
+        .checkNoError();
+  }
 }

--- a/packages/isar_plus/lib/src/native/bindings.dart
+++ b/packages/isar_plus/lib/src/native/bindings.dart
@@ -987,6 +987,25 @@ class IsarCoreBindings {
       _isar_closePtr
           .asFunction<int Function(ffi.Pointer<CIsarInstance>, bool)>();
 
+  int isar_delete_database(
+    ffi.Pointer<CString> name,
+    ffi.Pointer<CString> path,
+    bool sqlite,
+  ) {
+    return _isar_delete_database(name, path, sqlite);
+  }
+
+  late final _isar_delete_databasePtr = _lookup<
+    ffi.NativeFunction<
+      ffi.Uint8 Function(ffi.Pointer<CString>, ffi.Pointer<CString>, ffi.Bool)
+    >
+  >('isar_delete_database');
+  late final _isar_delete_database =
+      _isar_delete_databasePtr
+          .asFunction<
+            int Function(ffi.Pointer<CString>, ffi.Pointer<CString>, bool)
+          >();
+
   int isar_query_new(
     ffi.Pointer<CIsarInstance> isar,
     int collection_index,

--- a/packages/isar_plus/lib/src/web/bindings.dart
+++ b/packages/isar_plus/lib/src/web/bindings.dart
@@ -457,6 +457,15 @@ extension IsarBindingsX on JSIsar {
   external int isar_close(ffi.Pointer<CIsarInstance> isar, bool delete_);
 
   @ffi.Native<
+    ffi.Uint8 Function(ffi.Pointer<CString>, ffi.Pointer<CString>, ffi.Bool)
+  >(symbol: 'isar_delete_database')
+  external int isar_delete_database(
+    ffi.Pointer<CString> name,
+    ffi.Pointer<CString> path,
+    bool sqlite,
+  );
+
+  @ffi.Native<
     ffi.Uint8 Function(
       ffi.Pointer<CIsarInstance>,
       ffi.Uint16,


### PR DESCRIPTION
## 🚀 Feature: Database Deletion API

### Overview
This PR introduces a new static method `Isar.deleteDatabase()` that allows deleting database files without opening the database instance first. This is particularly useful for cleaning up corrupted or encrypted databases that cannot be opened due to incorrect encryption keys.

### Problem Solved
Previously, when an encryption key changed or was lost, users couldn't delete the encrypted database because:
- `close(deleteFromDisk: true)` requires opening the database first
- Opening fails with `EncryptionError` when the encryption key is wrong
- Users had to manually locate and delete database files

### Changes Made

#### 🦀 Rust Changes
- **New modules**: 
  - `packages/isar_core/src/native/native_delete.rs` - Native database file deletion
  - `packages/isar_core/src/sqlite/sqlite_delete.rs` - SQLite database file deletion
- **New FFI function**: `isar_delete_database()` in `packages/isar_core_ffi/src/instance.rs`
- **Engine-specific cleanup**: Each storage engine handles its own file patterns
  - **Native**: Removes `{name}.isar` and `{name}.isar.lock`
  - **SQLite**: Removes `{name}.sqlite`, `{name}.sqlite-wal`, and `{name}.sqlite-shm`

#### 🎯 Dart Changes
- **New API**: `Isar.deleteDatabase()` static method
- **Parameters**:
  - `name`: Database instance name
  - `directory`: Database directory path  
  - `engine`: Storage engine (Isar or SQLite)
- **FFI bindings**: Added to all binding files (native, impl, web)

### API Usage

```dart
// Delete an encrypted SQLite database that can't be opened
try {
  final isar = Isar.open(
    schemas: [UserSchema],
    directory: '/path/to/db',
    name: 'encrypted_db',
    engine: IsarEngine.sqlite,
    encryptionKey: 'wrong_key', // This will fail
  );
} on EncryptionError {
  // Clean up the corrupted/inaccessible database
  Isar.deleteDatabase(
    name: 'encrypted_db',
    directory: '/path/to/db',
    engine: IsarEngine.sqlite,
  );
  
  // Now recreate with new key
  final isar = Isar.open(
    schemas: [UserSchema],
    directory: '/path/to/db', 
    name: 'encrypted_db',
    engine: IsarEngine.sqlite,
    encryptionKey: 'new_key',
  );
}