### PR TITLE
fix: Add padding to Isar Connect URL in console output

### DIFF
--- a/packages/isar_plus/lib/src/isar_connect.dart
+++ b/packages/isar_plus/lib/src/isar_connect.dart
@@ -46,9 +46,10 @@ abstract class _IsarConnect {
     for (final handler in _handlers.entries) {
       registerExtension(handler.key.method, (method, parameters) async {
         try {
-          final args = parameters.containsKey('args')
-              ? jsonDecode(parameters['args']!) as Map<String, dynamic>
-              : <String, dynamic>{};
+          final args =
+              parameters.containsKey('args')
+                  ? jsonDecode(parameters['args']!) as Map<String, dynamic>
+                  : <String, dynamic>{};
           final result = <String, dynamic>{'result': await handler.value(args)};
           return ServiceExtensionResponse.result(jsonEncode(result));
         } on Exception catch (e) {
@@ -78,22 +79,22 @@ abstract class _IsarConnect {
         }
         final url =
             'https://isarplusinspector.ahmetaydin.dev/${Isar.version}/#/$port$path';
+        final width = url.length + 2;
         String line(String text, String fill) {
-          final fillCount = url.length - text.length;
+          final fillCount = width - text.length;
           final left = List.filled(fillCount ~/ 2, fill);
           final right = List.filled(fillCount - left.length, fill);
           return left.join() + text + right.join();
         }
 
-        final message =
-            '''
+        final message = '''
       ╔${line('', '═')}╗
       ║${line('ISAR CONNECT STARTED', ' ')}║
       ╟${line('', '─')}╢
       ║${line('Open the link to connect to the Isar', ' ')}║
       ║${line('Inspector while this build is running.', ' ')}║
       ╟${line('', '─')}╢
-      ║$url║
+      ║${line(url, ' ')}║
       ╚${line('', '═')}╝''';
         _logger.w(message);
       }),


### PR DESCRIPTION
### Problem
The Isar Connect URL in the console output was displayed adjacent to the border characters (e.g., `║https://...║`). This caused the trailing `║` to be included when selecting or double-clicking the URL, leading to connection errors.

### Solution
Added padding to the console output generation logic in [isar_connect.dart](https://github.com/ahmtydn/isar_plus/blob/cf8139e89852db5713eef54910f474c879db89e1/packages/isar_plus/lib/src/isar_connect.dart#L96C4-L96C13). The URL is now displayed with space around it (e.g., `║ https://... ║`), ensuring it can be copied correctly without capturing the border characters.