### PR TITLE
Chore/rename binaries and crates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,43 +47,43 @@ jobs:
         include:
           - name: "Android ARM64"
             os: ubuntu-latest
-            artifact_name: libisar_android_arm64.so
+            artifact_name: libisar_plus_android_arm64.so
             script: build_android.sh
-            upload_path: libisar_android_arm64.so
+            upload_path: libisar_plus_android_arm64.so
           - name: "Android ARMv7"
             os: ubuntu-latest
-            artifact_name: libisar_android_armv7.so
+            artifact_name: libisar_plus_android_armv7.so
             script: build_android.sh armv7
-            upload_path: libisar_android_armv7.so
+            upload_path: libisar_plus_android_armv7.so
           - name: "Android x64"
             os: ubuntu-latest
-            artifact_name: libisar_android_x64.so
+            artifact_name: libisar_plus_android_x64.so
             script: build_android.sh x64
-            upload_path: libisar_android_x64.so
+            upload_path: libisar_plus_android_x64.so
           - name: "Darwin XCFramework"
             os: macos-latest
-            artifact_name: IsarPlusCore.xcframework.zip
+            artifact_name: isar_plus_core.xcframework.zip
             script: build_darwin.sh
             upload_path: |
-              IsarPlusCore.xcframework.zip
-              IsarPlusCore.xcframework.zip.sha256
+              isar_plus_core.xcframework.zip
+              isar_plus_core.xcframework.zip.sha256
           - name: "Linux x64"
             os: ubuntu-latest
-            artifact_name: libisar_linux_x64.so
+            artifact_name: libisar_plus_linux_x64.so
             script: build_linux.sh x64
-            upload_path: libisar_linux_x64.so
+            upload_path: libisar_plus_linux_x64.so
           - name: "Windows x64"
             os: windows-latest
-            artifact_name: isar_windows_x64.dll
+            artifact_name: isar_plus_windows_x64.dll
             script: build_windows.sh x64
-            upload_path: isar_windows_x64.dll
+            upload_path: isar_plus_windows_x64.dll
           - name: "WebAssembly"
             os: ubuntu-latest
             artifact_name: wasm_files
             script: build_wasm.sh
             upload_path: |
-              isar.wasm
-              isar.js
+              isar_plus.wasm
+              isar_plus.js
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -157,14 +157,14 @@ jobs:
           fi
 
           gh release create ${{ needs.release_context.outputs.tag }} \
-            libisar_android_arm64.so \
-            libisar_android_armv7.so \
-            libisar_android_x64.so \
-            IsarPlusCore.xcframework.zip \
-            libisar_linux_x64.so \
-            isar_windows_x64.dll \
-            isar.wasm \
-            isar.js \
+            libisar_plus_android_arm64.so \
+            libisar_plus_android_armv7.so \
+            libisar_plus_android_x64.so \
+            isar_plus_core.xcframework.zip \
+            libisar_plus_linux_x64.so \
+            isar_plus_windows_x64.dll \
+            isar_plus.wasm \
+            isar_plus.js \
             --title "Isar Plus ${{ needs.release_context.outputs.tag }}" \
             --generate-notes \
             $PRERELEASE_FLAG
@@ -182,10 +182,10 @@ jobs:
 
       - name: Update Package.swift checksum and URL
         run: |
-          CHECKSUM=$(cat IsarPlusCore.xcframework.zip.sha256)
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/${{ needs.release_context.outputs.tag }}/IsarPlusCore.xcframework.zip"
+          CHECKSUM=$(cat isar_plus_core.xcframework.zip.sha256)
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/${{ needs.release_context.outputs.tag }}/isar_plus_core.xcframework.zip"
           sed -i \
-            -e "s|url: \".*IsarPlusCore.xcframework.zip\"|url: \"${RELEASE_URL}\"|" \
+            -e "s|url: \".*isar_plus_core.xcframework.zip\"|url: \"${RELEASE_URL}\"|" \
             -e "s|checksum: \".*\"|checksum: \"${CHECKSUM}\"|" \
             packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -386,7 +386,7 @@ jobs:
         run: |
           bash tool/build_android.sh x64
           mkdir -p packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64
-          mv libisar_android_x64.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64/libisar.so
+          mv libisar_plus_android_x64.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64/libisar_plus.so
       - name: Prepare Tests
         run: sh tool/prepare_tests.sh
       - name: Free Disk Space
@@ -425,17 +425,17 @@ jobs:
       - name: Download XCFramework
         uses: actions/download-artifact@v4
         with:
-          name: IsarPlusCore.xcframework.zip
+          name: isar_plus_core.xcframework.zip
           path: .
       - name: Extract XCFramework
-        run: unzip -o IsarPlusCore.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
+        run: unzip -o isar_plus_core.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
       - name: Prepare Tests
         run: sh tool/prepare_tests.sh
       - name: Run Flutter Driver tests
         run: |
           flutter config --enable-macos-desktop
           flutter config --enable-swift-package-manager
-          sed -i '' 's/url: ".*"/path: "Core\/IsarPlusCore.xcframework"/' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
+          sed -i '' 's/url: ".*"/path: "Core\/isar_plus_core.xcframework"/' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
           sed -i '' '/checksum: .*/d' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
 
           flutter test -d macos integration_test/isar_test.dart --dart-define STRESS=true 2>&1 | tee /tmp/flutter_test_output.txt
@@ -477,7 +477,7 @@ jobs:
       - name: Build Isar Core
         run: |
           bash tool/build_linux.sh x64
-          mv libisar_linux_x64.so packages/isar_plus_flutter_libs/linux/libisar.so
+          mv libisar_plus_linux_x64.so packages/isar_plus_flutter_libs/linux/libisar_plus.so
       - name: Prepare Tests
         run: sh tool/prepare_tests.sh
       - name: Run Flutter Driver tests
@@ -502,7 +502,7 @@ jobs:
       - name: Build Isar Core
         run: |
           bash tool/build_windows.sh x64
-          mv isar_windows_x64.dll packages/isar_plus_flutter_libs/windows/isar.dll
+          mv isar_plus_windows_x64.dll packages/isar_plus_flutter_libs/windows/isar_plus.dll
       - name: Prepare Tests
         run: sh tool/prepare_tests.sh
       - name: Run Flutter Driver tests
@@ -523,8 +523,8 @@ jobs:
       - name: Upload XCFramework
         uses: actions/upload-artifact@v4
         with:
-          name: IsarPlusCore.xcframework.zip
-          path: IsarPlusCore.xcframework.zip
+          name: isar_plus_core.xcframework.zip
+          path: isar_plus_core.xcframework.zip
           retention-days: 1
 
   integration_test_ios:
@@ -550,13 +550,13 @@ jobs:
       - name: Download XCFramework
         uses: actions/download-artifact@v4
         with:
-          name: IsarPlusCore.xcframework.zip
+          name: isar_plus_core.xcframework.zip
           path: .
 
       - name: Extract XCFramework
         run: |
           echo "Extracting XCFramework..."
-          unzip -o IsarPlusCore.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
+          unzip -o isar_plus_core.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
           ls -lh packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
 
       - name: Prepare Tests
@@ -574,7 +574,7 @@ jobs:
           # Enable SPM
           flutter config --enable-swift-package-manager
           # Patch Package.swift to use local path for testing
-          sed -i '' 's/url: ".*"/path: "Core\/IsarPlusCore.xcframework"/' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
+          sed -i '' 's/url: ".*"/path: "Core\/isar_plus_core.xcframework"/' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
           sed -i '' '/checksum: .*/d' ../isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
           
           # Get the specific device ID from the simulator action

--- a/.github/workflows/testlab.yaml
+++ b/.github/workflows/testlab.yaml
@@ -13,12 +13,12 @@ jobs:
         run: |
           bash tool/build_android.sh arm64
           mkdir -p packages/isar_plus_flutter_libs/android/src/main/jniLibs/arm64-v8a
-          mv libisar_android_arm64.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar.so
+          mv libisar_plus_android_arm64.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar_plus.so
       - name: Build Isar Core armv7
         run: |
           bash tool/build_android.sh armv7
           mkdir -p packages/isar_plus_flutter_libs/android/src/main/jniLibs/armeabi-v7a
-          mv libisar_android_armv7.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar.so
+          mv libisar_plus_android_armv7.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar_plus.so
       - name: Prepare Tests
         run: sh tool/prepare_tests.sh
       - name: Build dummy APK

--- a/docs/isar-plus-docs/content/docs/recipes/spm-migration.mdx
+++ b/docs/isar-plus-docs/content/docs/recipes/spm-migration.mdx
@@ -22,7 +22,7 @@ Prior to this migration, the plugin used separate CocoaPods podspecs for iOS and
 
 - Uses a **single `Package.swift`** at the plugin root for SPM configuration
 - Shares all Darwin (iOS + macOS) native source code under **`darwin/Classes/`**
-- Ships a **unified `IsarPlusCore.xcframework`** containing slices for iOS device, iOS simulator, and macOS
+- Ships a **unified `isar_plus_core.xcframework`** containing slices for iOS device, iOS simulator, and macOS
 - Removes all CocoaPods artifacts (`.podspec` files, `Podfile`, `Pods/` directories)
 
 ## New Darwin Shared Structure
@@ -41,7 +41,7 @@ The `darwin/Classes/` directory is the single source of truth for all Apple plat
 
 ## Unified XCFramework Structure
 
-The native Isar Core library is distributed as a single `IsarPlusCore.xcframework` containing three slices:
+The native Isar Core library is distributed as a single `isar_plus_core.xcframework` containing three slices:
 
 | Slice | Architecture | Description |
 |-------|-------------|-------------|

--- a/docs/isar-plus-docs/content/docs/recipes/spm-migration.tr.mdx
+++ b/docs/isar-plus-docs/content/docs/recipes/spm-migration.tr.mdx
@@ -22,7 +22,7 @@ Bu geçişten önce eklenti, iOS ve macOS için ayrı CocoaPods podspec dosyalar
 
 - Eklenti kökünde SPM yapılandırması için **tek bir `Package.swift`** kullanır
 - Tüm Darwin (iOS + macOS) native kaynak kodunu **`darwin/Classes/`** altında paylaşır
-- iOS cihaz, iOS simülatör ve macOS dilimlerini içeren **birleşik bir `IsarPlusCore.xcframework`** sunar
+- iOS cihaz, iOS simülatör ve macOS dilimlerini içeren **birleşik bir `isar_plus_core.xcframework`** sunar
 - Tüm CocoaPods artifactlarını (`.podspec` dosyaları, `Podfile`, `Pods/` dizinleri) kaldırır
 
 ## Yeni Darwin Paylaşımlı Yapısı
@@ -41,7 +41,7 @@ packages/isar_plus_flutter_libs/
 
 ## Birleşik XCFramework Yapısı
 
-Native Isar Core kütüphanesi, üç dilim içeren tek bir `IsarPlusCore.xcframework` olarak dağıtılır:
+Native Isar Core kütüphanesi, üç dilim içeren tek bir `isar_plus_core.xcframework` olarak dağıtılır:
 
 | Dilim | Mimari | Açıklama |
 |-------|--------|----------|

--- a/packages/isar_core/Cargo.toml
+++ b/packages/isar_core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "isar-core"
+name = "isar-plus-core"
 version = "0.0.0"
 authors = ["Simon Choi"]
 edition = "2021"

--- a/packages/isar_core_ffi/Cargo.toml
+++ b/packages/isar_core_ffi/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "isar"
+name = "isar-plus"
 version = "0.0.0"
 authors = ["Simon Choi"]
 edition = "2021"
 
 [dependencies]
-isar-core = { path = "../isar_core", default-features = false }
+isar_core = { package = "isar-plus-core", path = "../isar_core", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 
@@ -14,7 +14,7 @@ crate-type=["staticlib", "cdylib"]
 
 [features]
 default = ["sqlite", "native"]
-native = ["isar-core/native"]
-sqlite = ["isar-core/sqlite"]
-sqlcipher = ["sqlite", "isar-core/sqlcipher"]
-sqlcipher-vendored = ["sqlcipher", "isar-core/sqlcipher-vendored"]
+native = ["isar_core/native"]
+sqlite = ["isar_core/sqlite"]
+sqlcipher = ["sqlite", "isar_core/sqlcipher"]
+sqlcipher-vendored = ["sqlcipher", "isar_core/sqlcipher-vendored"]

--- a/packages/isar_plus/CHANGELOG.md
+++ b/packages/isar_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* refactor: rename all compiled native binary filenames, Rust crate names, and Apple SPM package architectures from `isar` to `isar_plus` (e.g. `libisar` -> `libisar_plus`, `IsarPlusCore` -> `isar_plus_core`) to eliminate naming conflicts and fully align the codebase to the project package namespace.
+
 ## 1.2.9
 
 * fix(native): prevent Scudo `invalid chunk state` crash in async operations by removing per-task `IsarCore` buffer cleanup when running on long-lived worker pool isolates.

--- a/packages/isar_plus/CHANGELOG.md
+++ b/packages/isar_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.0
 
 * refactor: rename all compiled native binary filenames, Rust crate names, and Apple SPM package architectures from `isar` to `isar_plus` (e.g. `libisar` -> `libisar_plus`, `IsarPlusCore` -> `isar_plus_core`) to eliminate naming conflicts and fully align the codebase to the project package namespace.
+* breaking: change default background worker pool count to 1 (down from a processors clamp) to prioritize memory efficiency. Use `Isar.setWorkerCount()` to increase this value for heavier asynchronous workloads.
 
 ## 1.2.9
 

--- a/packages/isar_plus/lib/src/isar.dart
+++ b/packages/isar_plus/lib/src/isar.dart
@@ -40,9 +40,8 @@ abstract class Isar {
   /// Sets the number of background workers to be used for asynchronous
   /// operations.
   ///
-  /// By default, Isar uses `(Platform.numberOfProcessors - 1).clamp(2, 8)`
-  /// workers. Increasing this number can improve performance for heavy
-  /// workloads but will consume more memory.
+  /// By default, Isar uses `1` worker. Increasing this number can improve
+  /// performance for heavy workloads but will consume more memory.
   ///
   /// This method is only available on native platforms and must be called
   /// before any database operations.

--- a/packages/isar_plus/lib/src/native/native.dart
+++ b/packages/isar_plus/lib/src/native/native.dart
@@ -68,15 +68,15 @@ extension on Abi {
       case Abi.androidArm:
       case Abi.androidArm64:
       case Abi.androidX64:
-        return 'libisar.so';
+        return 'libisar_plus.so';
       case Abi.macosArm64:
       case Abi.macosX64:
-        return 'libisar.dylib';
+        return 'libisar_plus.dylib';
       case Abi.linuxX64:
-        return 'libisar.so';
+        return 'libisar_plus.so';
       case Abi.windowsArm64:
       case Abi.windowsX64:
-        return 'isar.dll';
+        return 'isar_plus.dll';
       case Abi.androidIA32:
         throw IsarNotReadyError(
           'Unsupported processor architecture. X86 Android emulators are not '

--- a/packages/isar_plus/lib/src/native/worker_pool.dart
+++ b/packages/isar_plus/lib/src/native/worker_pool.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
-import 'dart:io';
 import 'dart:isolate';
 
-import 'package:logger/logger.dart';
 import 'package:meta/meta.dart' show visibleForTesting;
 
 /// A function type that represents a unit of work to be executed on a worker
@@ -56,9 +54,9 @@ class _PendingTask<T> {
 ///
 /// ## Worker count
 ///
-/// By default the pool creates `(Platform.numberOfProcessors - 1).clamp(2, 8)`
-/// workers. This can be overridden before the first [run] call using
-/// [configure].
+/// By default the pool creates 1 worker. This can be overridden
+/// before the first
+/// [run] call using [configure].
 ///
 /// ## Usage
 ///
@@ -84,14 +82,6 @@ class _PendingTask<T> {
 class IsarWorkerPool {
   // Private constructor prevents instantiation – this is a purely static API.
   IsarWorkerPool._();
-
-  static final _logger = Logger(
-    printer: PrettyPrinter(
-      methodCount: 0,
-      errorMethodCount: 0,
-      printEmojis: false,
-    ),
-  );
 
   /// Overrides the default worker count set by [configure].
   ///
@@ -131,7 +121,6 @@ class IsarWorkerPool {
   /// ```
   static void configure(int workerCount) {
     if (_initFuture != null) {
-      _logger.w('Worker count can only be configured before the first run');
       return;
     }
     _customWorkerCount = workerCount.clamp(1, 16);
@@ -140,11 +129,10 @@ class IsarWorkerPool {
   /// Returns the number of workers that will be (or have been) spawned.
   ///
   /// When a custom value has been set via [configure] that value is returned.
-  /// Otherwise the count is derived from [Platform.numberOfProcessors]:
-  /// `(processors - 1).clamp(2, 8)`.
+  /// Otherwise the count defaults to 1.
   static int get _workerCount {
     if (_customWorkerCount != null) return _customWorkerCount!;
-    return (Platform.numberOfProcessors - 1).clamp(2, 8);
+    return 1;
   }
 
   /// Explicitly starts the worker isolates in the background.

--- a/packages/isar_plus/lib/src/native/worker_pool.dart
+++ b/packages/isar_plus/lib/src/native/worker_pool.dart
@@ -177,7 +177,7 @@ class IsarWorkerPool {
       workers = await Future.wait(futures);
     } catch (_) {
       for (final future in futures) {
-        future.then((w) => w.dispose(), onError: (_) {});
+        unawaited(future.then((w) => w.dispose(), onError: (_) {}));
       }
       _initFuture = null;
       rethrow;
@@ -249,9 +249,14 @@ class IsarWorkerPool {
     if (!_allWorkers.contains(worker)) return;
     while (_pendingQueue.isNotEmpty) {
       final task = _pendingQueue.removeFirst();
-      worker
-          .execute(task.computation, _onWorkerIdle)
-          .then(task.completer.complete, onError: task.completer.completeError);
+      unawaited(
+        worker
+            .execute(task.computation, _onWorkerIdle)
+            .then(
+              task.completer.complete,
+              onError: task.completer.completeError,
+            ),
+      );
       return;
     }
     _idleWorkers.addLast(worker);
@@ -293,7 +298,7 @@ class _WorkerHandle {
   /// [_WorkerHandle] connected to it.
   ///
   /// The isolate runs [_workerEntry] and signals readiness by sending back its
-  /// own [SendPort] on [receivePort].
+  /// own [SendPort] on `receivePort`.
   ///
   /// The spawned isolate is configured with `errorsAreFatal: false` so that
   /// uncaught errors in the isolate do not kill the entire process; errors are

--- a/packages/isar_plus_flutter_libs/CHANGELOG.md
+++ b/packages/isar_plus_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* refactor: rename all compiled native binary filenames, Rust crate names, and Apple SPM package architectures from `isar` to `isar_plus` (e.g. `libisar` -> `libisar_plus`, `IsarPlusCore` -> `isar_plus_core`) to eliminate naming conflicts and fully align the codebase to the project package namespace.
+
 ## 1.2.9
 
 * fix(native): prevent Scudo `invalid chunk state` crash in async operations by removing per-task `IsarCore` buffer cleanup when running on long-lived worker pool isolates.

--- a/packages/isar_plus_flutter_libs/CHANGELOG.md
+++ b/packages/isar_plus_flutter_libs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.0
 
 * refactor: rename all compiled native binary filenames, Rust crate names, and Apple SPM package architectures from `isar` to `isar_plus` (e.g. `libisar` -> `libisar_plus`, `IsarPlusCore` -> `isar_plus_core`) to eliminate naming conflicts and fully align the codebase to the project package namespace.
+* breaking: change default background worker pool count to 1 (down from a processors clamp) to prioritize memory efficiency. Use `Isar.setWorkerCount()` to increase this value for heavier asynchronous workloads.
 
 ## 1.2.9
 

--- a/packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
+++ b/packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift
@@ -15,13 +15,13 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "IsarPlusCore",
-            url: "https://github.com/ahmtydn/isar_plus/releases/download/0.0.0-placeholder/IsarPlusCore.xcframework.zip",
+            name: "isar_plus_core",
+            url: "https://github.com/ahmtydn/isar_plus/releases/download/0.0.0-placeholder/isar_plus_core.xcframework.zip",
             checksum: "0000000000000000000000000000000000000000000000000000000000000000"
         ),
         .target(
             name: "CIsarCore",
-            dependencies: ["IsarPlusCore"],
+            dependencies: ["isar_plus_core"],
             path: "Core"
         ),
         .target(

--- a/packages/isar_plus_flutter_libs/linux/CMakeLists.txt
+++ b/packages/isar_plus_flutter_libs/linux/CMakeLists.txt
@@ -20,6 +20,6 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(isar_plus_flutter_libs_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/libisar.so"
+  "${CMAKE_CURRENT_SOURCE_DIR}/libisar_plus.so"
   PARENT_SCOPE
 )

--- a/packages/isar_plus_flutter_libs/windows/CMakeLists.txt
+++ b/packages/isar_plus_flutter_libs/windows/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(isar_plus_flutter_libs_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/isar.dll"
+  "${CMAKE_CURRENT_SOURCE_DIR}/isar_plus.dll"
   PARENT_SCOPE
 )

--- a/packages/isar_plus_test/lib/src/init_web.dart
+++ b/packages/isar_plus_test/lib/src/init_web.dart
@@ -4,7 +4,7 @@ import 'package:isar_plus_test/src/common.dart';
 var _setUp = false;
 Future<void> prepareTest() async {
   if (!_setUp) {
-    await Isar.initialize('http://localhost:3000/isar.wasm');
+    await Isar.initialize('http://localhost:3000/isar_plus.wasm');
     testTempPath = '/isar_test';
     _setUp = true;
   }

--- a/tool/build_android.sh
+++ b/tool/build_android.sh
@@ -61,15 +61,15 @@ cd packages/isar_core_ffi
 if [ "$1" = "x64" ]; then
   rustup target add x86_64-linux-android
   cargo build --target x86_64-linux-android --features sqlcipher-vendored --release
-  cp "../../target/x86_64-linux-android/release/libisar.so" "../../libisar_android_x64.so"
+  cp "../../target/x86_64-linux-android/release/libisar_plus.so" "../../libisar_plus_android_x64.so"
 elif [ "$1" = "armv7" ]; then
   rustup target add armv7-linux-androideabi
   cargo build --target armv7-linux-androideabi --features sqlcipher-vendored --release
-  cp "../../target/armv7-linux-androideabi/release/libisar.so" "../../libisar_android_armv7.so"
+  cp "../../target/armv7-linux-androideabi/release/libisar_plus.so" "../../libisar_plus_android_armv7.so"
 else
   rustup target add aarch64-linux-android
   cargo build --target aarch64-linux-android --features sqlcipher-vendored --release
-  cp "../../target/aarch64-linux-android/release/libisar.so" "../../libisar_android_arm64.so"
+  cp "../../target/aarch64-linux-android/release/libisar_plus.so" "../../libisar_plus_android_arm64.so"
 fi
 
 

--- a/tool/build_darwin.sh
+++ b/tool/build_darwin.sh
@@ -15,45 +15,45 @@ rustup target add \
 
 # iOS device
 echo "Building for aarch64-apple-ios..."
-cargo build -p isar --target aarch64-apple-ios --features sqlcipher --release
+cargo build -p isar-plus --target aarch64-apple-ios --features sqlcipher --release
 
 # iOS simulator — create universal binary
 echo "Building for aarch64-apple-ios-sim..."
-cargo build -p isar --target aarch64-apple-ios-sim --features sqlcipher --release
+cargo build -p isar-plus --target aarch64-apple-ios-sim --features sqlcipher --release
 
 echo "Building for x86_64-apple-ios..."
-cargo build -p isar --target x86_64-apple-ios --features sqlcipher --release
+cargo build -p isar-plus --target x86_64-apple-ios --features sqlcipher --release
 
 echo "Creating universal iOS simulator binary..."
 mkdir -p build/ios-simulator
-lipo target/aarch64-apple-ios-sim/release/libisar.a \
-     target/x86_64-apple-ios/release/libisar.a \
-     -output build/ios-simulator/libisar.a -create
+lipo target/aarch64-apple-ios-sim/release/libisar_plus.a \
+     target/x86_64-apple-ios/release/libisar_plus.a \
+     -output build/ios-simulator/libisar_plus.a -create
 
 # macOS — create universal static binary
 echo "Building for aarch64-apple-darwin..."
-cargo build -p isar --target aarch64-apple-darwin --features sqlcipher --release
+cargo build -p isar-plus --target aarch64-apple-darwin --features sqlcipher --release
 
 echo "Building for x86_64-apple-darwin..."
-cargo build -p isar --target x86_64-apple-darwin --features sqlcipher --release
+cargo build -p isar-plus --target x86_64-apple-darwin --features sqlcipher --release
 
 echo "Creating universal macOS binary..."
 mkdir -p build/macos
-lipo target/aarch64-apple-darwin/release/libisar.a \
-     target/x86_64-apple-darwin/release/libisar.a \
-     -output build/macos/libisar.a -create
+lipo target/aarch64-apple-darwin/release/libisar_plus.a \
+     target/x86_64-apple-darwin/release/libisar_plus.a \
+     -output build/macos/libisar_plus.a -create
 
 # Assemble unified XCFramework
-echo "Assembling IsarPlusCore.xcframework..."
+echo "Assembling isar_plus_core.xcframework..."
 xcodebuild -create-xcframework \
-    -library target/aarch64-apple-ios/release/libisar.a \
-    -library build/ios-simulator/libisar.a \
-    -library build/macos/libisar.a \
-    -output IsarPlusCore.xcframework
+    -library target/aarch64-apple-ios/release/libisar_plus.a \
+    -library build/ios-simulator/libisar_plus.a \
+    -library build/macos/libisar_plus.a \
+    -output isar_plus_core.xcframework
 
 echo "Creating archive..."
-zip -r IsarPlusCore.xcframework.zip IsarPlusCore.xcframework
+zip -r isar_plus_core.xcframework.zip isar_plus_core.xcframework
 
 echo "Computing checksum..."
-shasum -a 256 IsarPlusCore.xcframework.zip | awk '{print $1}' > IsarPlusCore.xcframework.zip.sha256
-echo "Checksum: $(cat IsarPlusCore.xcframework.zip.sha256)"
+shasum -a 256 isar_plus_core.xcframework.zip | awk '{print $1}' > isar_plus_core.xcframework.zip.sha256
+echo "Checksum: $(cat isar_plus_core.xcframework.zip.sha256)"

--- a/tool/build_linux.sh
+++ b/tool/build_linux.sh
@@ -3,10 +3,10 @@ set -e
 
 if [ "$1" = "x64" ]; then
   rustup target add x86_64-unknown-linux-gnu
-  cargo build -p isar --target x86_64-unknown-linux-gnu --features sqlcipher-vendored --release
-  cp "target/x86_64-unknown-linux-gnu/release/libisar.so" "libisar_linux_x64.so"
+  cargo build -p isar-plus --target x86_64-unknown-linux-gnu --features sqlcipher-vendored --release
+  cp "target/x86_64-unknown-linux-gnu/release/libisar_plus.so" "libisar_plus_linux_x64.so"
 else
   rustup target add aarch64-unknown-linux-gnu
-  cargo build -p isar --target aarch64-unknown-linux-gnu --features sqlcipher-vendored --release
-  cp "target/aarch64-unknown-linux-gnu/release/libisar.so" "libisar_linux_arm64.so"
+  cargo build -p isar-plus --target aarch64-unknown-linux-gnu --features sqlcipher-vendored --release
+  cp "target/aarch64-unknown-linux-gnu/release/libisar_plus.so" "libisar_plus_linux_arm64.so"
 fi

--- a/tool/build_wasm.sh
+++ b/tool/build_wasm.sh
@@ -7,30 +7,30 @@ cargo build \
        --target wasm32-unknown-unknown \
        --no-default-features \
        --features sqlite \
-       -p isar \
+       -p isar-plus \
        --release
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-WASM_TARGET="${ROOT_DIR}/target/wasm32-unknown-unknown/release/isar.wasm"
+WASM_TARGET="${ROOT_DIR}/target/wasm32-unknown-unknown/release/isar_plus.wasm"
 
 wasm-bindgen \
        "${WASM_TARGET}" \
        --out-dir "${ROOT_DIR}" \
-       --out-name isar \
+       --out-name isar_plus \
        --target no-modules \
        --no-typescript
 
-# The wasm-bindgen output will be isar_bg.wasm, rename to isar.wasm
-mv "${ROOT_DIR}/isar_bg.wasm" "${ROOT_DIR}/isar.wasm"
+# The wasm-bindgen output will be isar_plus_bg.wasm, rename to isar_plus.wasm
+mv "${ROOT_DIR}/isar_plus_bg.wasm" "${ROOT_DIR}/isar_plus.wasm"
 
-sed -i.bak '1s/let wasm_bindgen/window.wasm_bindgen/' "${ROOT_DIR}/isar.js"
-rm -f "${ROOT_DIR}/isar.js.bak"
+sed -i.bak '1s/let wasm_bindgen/window.wasm_bindgen/' "${ROOT_DIR}/isar_plus.js"
+rm -f "${ROOT_DIR}/isar_plus.js.bak"
 
 # Optimize the WASM file with required feature flags
 if command -v wasm-opt &> /dev/null; then
     wasm-opt -O3 \
         --enable-bulk-memory \
         --enable-nontrapping-float-to-int \
-        "${ROOT_DIR}/isar.wasm" \
-        -o "${ROOT_DIR}/isar.wasm"
+        "${ROOT_DIR}/isar_plus.wasm" \
+    -o "${ROOT_DIR}/isar_plus.wasm"
 fi

--- a/tool/build_windows.sh
+++ b/tool/build_windows.sh
@@ -15,12 +15,12 @@ export RUSTFLAGS="-C linker=lld-link -C link-arg=/IGNORE:4099"
 
 if [ "$1" = "x64" ]; then
   rustup target add x86_64-pc-windows-msvc
-  cargo build -p isar --target x86_64-pc-windows-msvc --features sqlcipher-vendored --release
-  cp "target/x86_64-pc-windows-msvc/release/isar.dll" "isar_windows_x64.dll"
+  cargo build -p isar-plus --target x86_64-pc-windows-msvc --features sqlcipher-vendored --release
+  cp "target/x86_64-pc-windows-msvc/release/isar_plus.dll" "isar_plus_windows_x64.dll"
   echo "✅ Windows x64 build completed (native compilation)"
 else
   rustup target add aarch64-pc-windows-msvc
-  cargo build -p isar --target aarch64-pc-windows-msvc --features sqlcipher-vendored --release
-  cp "target/aarch64-pc-windows-msvc/release/isar.dll" "isar_windows_arm64.dll"
+  cargo build -p isar-plus --target aarch64-pc-windows-msvc --features sqlcipher-vendored --release
+  cp "target/aarch64-pc-windows-msvc/release/isar_plus.dll" "isar_plus_windows_arm64.dll"
   echo "✅ Windows ARM64 build completed (native compilation)"
 fi

--- a/tool/cbindgen.toml
+++ b/tool/cbindgen.toml
@@ -2,7 +2,7 @@ language = "C"
 
 [parse]
 parse_deps = true
-include = ["isar-core", "isar"]
+include = ["isar-plus-core", "isar-plus"]
 
 [parse.expand]
-crates = ["isar"]
+crates = ["isar-plus"]

--- a/tool/download_binaries.sh
+++ b/tool/download_binaries.sh
@@ -8,13 +8,13 @@ fi
 github="https://github.com/ahmtydn/isar_plus/releases/download/$ISAR_VERSION"
 
 
-curl "${github}/libisar_android_arm64.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar.so --create-dirs -L -f
-curl "${github}/libisar_android_armv7.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar.so --create-dirs -L -f
-curl "${github}/libisar_android_x64.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64/libisar.so --create-dirs -L
+curl "${github}/libisar_plus_android_arm64.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar_plus.so --create-dirs -L -f
+curl "${github}/libisar_plus_android_armv7.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar_plus.so --create-dirs -L -f
+curl "${github}/libisar_plus_android_x64.so" -o packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64/libisar_plus.so --create-dirs -L
 
 
-curl "${github}/libisar_linux_x64.so" -o packages/isar_plus_flutter_libs/linux/libisar.so --create-dirs -L -f
-curl "${github}/isar_windows_x64.dll" -o packages/isar_plus_flutter_libs/windows/isar.dll --create-dirs -L -f
+curl "${github}/libisar_plus_linux_x64.so" -o packages/isar_plus_flutter_libs/linux/libisar_plus.so --create-dirs -L -f
+curl "${github}/isar_plus_windows_x64.dll" -o packages/isar_plus_flutter_libs/windows/isar_plus.dll --create-dirs -L -f
 
-curl "${github}/isar.wasm" -o isar.wasm -L -f
-curl "${github}/isar.js" -o isar.js -L -f
+curl "${github}/isar_plus.wasm" -o isar_plus.wasm -L -f
+curl "${github}/isar_plus.js" -o isar_plus.js -L -f

--- a/tool/generate_bindings.sh
+++ b/tool/generate_bindings.sh
@@ -2,7 +2,7 @@
 
 cargo install cbindgen
 
-cbindgen --config tool/cbindgen.toml --crate isar --output packages/isar_plus/isar-dart.h
+cbindgen --config tool/cbindgen.toml --crate isar-plus --output packages/isar_plus/isar-dart.h
 
 cd packages/isar_plus
 

--- a/tool/prepare_local_dev.sh
+++ b/tool/prepare_local_dev.sh
@@ -84,17 +84,17 @@ echo "Preparing local Isar Plus artifacts for targets: ${TARGETS[*]}"
 
 # Clean existing build artifacts before building
 echo "\n==> Cleaning existing build artifacts"
-rm -f "$REPO_ROOT/IsarPlusCore.xcframework.zip"
-rm -rf "$REPO_ROOT/IsarPlusCore.xcframework"
-rm -f "$REPO_ROOT/isar.wasm"
-rm -f "$REPO_ROOT/isar.js"
-rm -f "$REPO_ROOT/libisar_android_arm64.so"
-rm -f "$REPO_ROOT/libisar_android_armv7.so"
-rm -f "$REPO_ROOT/libisar_android_x64.so"
-rm -f "$REPO_ROOT/libisar_linux_x64.so"
-rm -f "$REPO_ROOT/isar_windows_x64.dll"
-rm -f "$EXAMPLE_DIR/web/isar.wasm"
-rm -f "$EXAMPLE_DIR/web/isar.js"
+rm -f "$REPO_ROOT/isar_plus_core.xcframework.zip"
+rm -rf "$REPO_ROOT/isar_plus_core.xcframework"
+rm -f "$REPO_ROOT/isar_plus.wasm"
+rm -f "$REPO_ROOT/isar_plus.js"
+rm -f "$REPO_ROOT/libisar_plus_android_arm64.so"
+rm -f "$REPO_ROOT/libisar_plus_android_armv7.so"
+rm -f "$REPO_ROOT/libisar_plus_android_x64.so"
+rm -f "$REPO_ROOT/libisar_plus_linux_x64.so"
+rm -f "$REPO_ROOT/isar_plus_windows_x64.dll"
+rm -f "$EXAMPLE_DIR/web/isar_plus.wasm"
+rm -f "$EXAMPLE_DIR/web/isar_plus.js"
 echo "Build artifacts cleaned"
 
 declare -a built_artifacts=()
@@ -103,18 +103,18 @@ if has_target "darwin"; then
   echo "\n==> Building Darwin unified XCFramework"
   bash "$SCRIPT_DIR/build_darwin.sh"
   DARWIN_DIR="$REPO_ROOT/packages/isar_plus_flutter_libs/darwin"
-  rm -rf "$DARWIN_DIR/IsarPlusCore.xcframework"
-  unzip -qo "$REPO_ROOT/IsarPlusCore.xcframework.zip" -d "$DARWIN_DIR"
-  built_artifacts+=("darwin xcframework -> packages/isar_plus_flutter_libs/darwin/IsarPlusCore.xcframework")
+  rm -rf "$DARWIN_DIR/isar_plus_core.xcframework"
+  unzip -qo "$REPO_ROOT/isar_plus_core.xcframework.zip" -d "$DARWIN_DIR"
+  built_artifacts+=("darwin xcframework -> packages/isar_plus_flutter_libs/darwin/isar_plus_core.xcframework")
 fi
 
 if has_target "wasm"; then
   echo "\n==> Building WebAssembly bundle"
   bash "$SCRIPT_DIR/build_wasm.sh"
   mkdir -p "$EXAMPLE_DIR/web"
-  cp "$REPO_ROOT/isar.wasm" "$EXAMPLE_DIR/web/isar.wasm"
-  cp "$REPO_ROOT/isar.js" "$EXAMPLE_DIR/web/isar.js"
-  built_artifacts+=("web wasm -> isar.wasm and isar.js")
+  cp "$REPO_ROOT/isar_plus.wasm" "$EXAMPLE_DIR/web/isar_plus.wasm"
+  cp "$REPO_ROOT/isar_plus.js" "$EXAMPLE_DIR/web/isar_plus.js"
+  built_artifacts+=("web wasm -> isar_plus.wasm and isar_plus.js")
 fi
 
 ANDROID_LIB_DIR="$REPO_ROOT/packages/isar_plus_flutter_libs/android/src/main/jniLibs"
@@ -122,40 +122,40 @@ if has_target "android-arm64"; then
   echo "\n==> Building Android ARM64"
   bash "$SCRIPT_DIR/build_android.sh"
   mkdir -p "$ANDROID_LIB_DIR/arm64-v8a"
-  cp "$REPO_ROOT/libisar_android_arm64.so" "$ANDROID_LIB_DIR/arm64-v8a/libisar.so"
-  built_artifacts+=("android arm64 -> .../jniLibs/arm64-v8a/libisar.so")
+  cp "$REPO_ROOT/libisar_plus_android_arm64.so" "$ANDROID_LIB_DIR/arm64-v8a/libisar_plus.so"
+  built_artifacts+=("android arm64 -> .../jniLibs/arm64-v8a/libisar_plus.so")
 fi
 
 if has_target "android-armv7"; then
   echo "\n==> Building Android ARMv7"
   bash "$SCRIPT_DIR/build_android.sh" armv7
   mkdir -p "$ANDROID_LIB_DIR/armeabi-v7a"
-  cp "$REPO_ROOT/libisar_android_armv7.so" "$ANDROID_LIB_DIR/armeabi-v7a/libisar.so"
-  built_artifacts+=("android armv7 -> .../jniLibs/armeabi-v7a/libisar.so")
+  cp "$REPO_ROOT/libisar_plus_android_armv7.so" "$ANDROID_LIB_DIR/armeabi-v7a/libisar_plus.so"
+  built_artifacts+=("android armv7 -> .../jniLibs/armeabi-v7a/libisar_plus.so")
 fi
 
 if has_target "android-x64"; then
   echo "\n==> Building Android x64"
   bash "$SCRIPT_DIR/build_android.sh" x64
   mkdir -p "$ANDROID_LIB_DIR/x86_64"
-  cp "$REPO_ROOT/libisar_android_x64.so" "$ANDROID_LIB_DIR/x86_64/libisar.so"
-  built_artifacts+=("android x64 -> .../jniLibs/x86_64/libisar.so")
+  cp "$REPO_ROOT/libisar_plus_android_x64.so" "$ANDROID_LIB_DIR/x86_64/libisar_plus.so"
+  built_artifacts+=("android x64 -> .../jniLibs/x86_64/libisar_plus.so")
 fi
 
 if has_target "linux-x64"; then
   echo "\n==> Building Linux x64"
   bash "$SCRIPT_DIR/build_linux.sh" x64
   mkdir -p "$REPO_ROOT/packages/isar_plus_flutter_libs/linux"
-  cp "$REPO_ROOT/libisar_linux_x64.so" "$REPO_ROOT/packages/isar_plus_flutter_libs/linux/libisar.so"
-  built_artifacts+=("linux x64 -> packages/isar_plus_flutter_libs/linux/libisar.so")
+  cp "$REPO_ROOT/libisar_plus_linux_x64.so" "$REPO_ROOT/packages/isar_plus_flutter_libs/linux/libisar_plus.so"
+  built_artifacts+=("linux x64 -> packages/isar_plus_flutter_libs/linux/libisar_plus.so")
 fi
 
 if has_target "windows-x64"; then
   echo "\n==> Building Windows x64"
   bash "$SCRIPT_DIR/build_windows.sh" x64
   mkdir -p "$REPO_ROOT/packages/isar_plus_flutter_libs/windows"
-  cp "$REPO_ROOT/isar_windows_x64.dll" "$REPO_ROOT/packages/isar_plus_flutter_libs/windows/isar.dll"
-  built_artifacts+=("windows x64 -> packages/isar_plus_flutter_libs/windows/isar.dll")
+  cp "$REPO_ROOT/isar_plus_windows_x64.dll" "$REPO_ROOT/packages/isar_plus_flutter_libs/windows/isar_plus.dll"
+  built_artifacts+=("windows x64 -> packages/isar_plus_flutter_libs/windows/isar_plus.dll")
 fi
 
 if [[ ! -d "$EXAMPLE_DIR" ]]; then


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR performs a mechanical rename of all native binary artifacts, Rust crate names, and the Apple SPM framework from legacy `isar`/`IsarPlusCore` identifiers to the unified `isar_plus`/`isar_plus_core` namespace, eliminating naming conflicts with the upstream `isar` package. It also bundles a default-worker-count reduction (documented in the CHANGELOG) and removes the `logger` dependency from the worker pool.

- **Binary rename (all platforms):** Android `.so` files, the Darwin XCFramework bundle, Linux `.so`, Windows `.dll`, and WASM outputs are all renamed to the `isar_plus` prefix; build scripts, CI workflows, CMake files, Package.swift, and the Dart `DynamicLibrary.open()` calls are updated in lockstep.
- **Cargo crate renames:** `isar-core` → `isar-plus-core` and `isar` → `isar-plus`; the FFI crate uses a local alias (`isar_core`) so feature-flag references compile correctly.
- **Worker pool cleanup:** Default worker count changed to 1 (breaking, documented in CHANGELOG); `logger` dependency removed; `unawaited()` added for two fire-and-forget futures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the rename is applied consistently across all build scripts, CI workflows, CMake files, Package.swift, and the Dart FFI layer.

The change is a mechanical rename touching 25 files. Every artifact name, crate reference, and library filename is updated in lockstep from source (Cargo.toml) through build scripts, CI workflows, CMake/Package.swift packaging, and the Dart DynamicLibrary.open() call. The Cargo dependency alias is correct syntax and feature flags reference the alias correctly. The worker-count reduction is a documented breaking change in the CHANGELOG. No dangling old-name references were found.

No files require special attention — the rename is complete and consistent throughout the repository.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Artifact names updated throughout: Android `.so`, Darwin xcframework zip, Linux `.so`, Windows `.dll`, and WASM files all renamed from `isar`/`IsarPlusCore` to `isar_plus`/`isar_plus_core`; sed patterns updated to match new xcframework filename. |
| .github/workflows/test.yaml | All artifact download names, unzip targets, `mv` destinations, and SPM `sed` path patches updated consistently to the new `isar_plus` naming scheme across all platform integration-test jobs. |
| packages/isar_core_ffi/Cargo.toml | Crate renamed from `isar` to `isar-plus`; dependency on `isar-core` aliased correctly via `package = "isar-plus-core"` with underscore alias so feature flags (`isar_core/native`, etc.) compile correctly. |
| packages/isar_plus/lib/src/native/native.dart | All platform-specific library filenames updated: Android/Linux use `libisar_plus.so`, macOS uses `libisar_plus.dylib`, Windows uses `isar_plus.dll`; consistent with build-script output filenames. |
| packages/isar_plus/lib/src/native/worker_pool.dart | Default worker count hardcoded to 1 (down from adaptive clamp); logger dependency removed along with the configure-after-init warning; `unawaited()` added for two fire-and-forget futures. |
| packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Package.swift | SPM binary target renamed from `IsarPlusCore` to `isar_plus_core` and `CIsarCore` dependency updated accordingly; placeholder URL and checksum updated to new xcframework name. |
| tool/build_darwin.sh | All cargo build targets use `-p isar-plus`; lipo inputs/outputs updated to `libisar_plus.a`; xcodebuild output renamed to `isar_plus_core.xcframework` and the zip/sha256 filenames match. |
| tool/download_binaries.sh | All download URLs and destination filenames updated from `isar`/`isar_windows` to `isar_plus` naming; consistent with release asset names. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/isar_plus/lib/src/native/worker_pool.dart`, line 114-116 ([link](https://github.com/ahmtydn/isar_plus/blob/8fa4987a19b77c59f0078b121042d6829659a384/packages/isar_plus/lib/src/native/worker_pool.dart#L114-L116)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The doc comment still promises "a warning is printed instead" when `configure()` is called after initialization, but the logger and its warning were removed. Callers who rely on this diagnostic will silently get no feedback.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["breaking: reduce default background work..."](https://github.com/ahmtydn/isar_plus/commit/fcddaccd9ba402c033467519232de62991940d25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34521288)</sub>

<!-- /greptile_comment -->