### PR TITLE
melos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,14 +206,7 @@ jobs:
           mkdir -p $HOME/.config/dart
           echo '${{ secrets.PUB_JSON }}' >> $HOME/.config/dart/pub-credentials.json
 
-      - name: Publish isar
-        run: |
-          dart pub get
-          dart pub publish --force
-        working-directory: packages/isar_plus
-
-      - name: Publish isar_plus_flutter_libs
-        run: |
-          flutter pub get
-          flutter pub publish --force
-        working-directory: packages/isar_plus_flutter_libs
+      - name: Bootstrap
+        run: flutter pub get
+      - name: Publish packages
+        run: dart run melos publish --no-dry-run --yes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,20 +59,12 @@ jobs:
           cache: true
       - name: Enable Swift Package Manager
         run: flutter config --enable-swift-package-manager
-      - run: dart pub get
-        working-directory: packages/isar_plus
-      - run: flutter pub get
-        working-directory: packages/isar_plus_flutter_libs
-      - run: flutter pub get
-        working-directory: packages/isar_plus_inspector
-      - run: |
-          flutter pub get
-          flutter pub run build_runner build
-          dart tool/generate_all_tests.dart
-        working-directory: packages/isar_plus_test
+      - name: Bootstrap
+        run: flutter pub get
+      - name: Prepare Tests
+        run: dart run melos run test:prepare
       - name: Lint
-        run: flutter analyze
-        working-directory: packages
+        run: dart run melos run analyze
 
   test_core:
     name: Core Test
@@ -105,11 +97,12 @@ jobs:
         uses: ./.github/actions/prepare-build
       - name: Build Isar Core
         run: sh tool/build.sh
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Run Flutter Unit tests
-        run: flutter test -j 1
-        working-directory: packages/isar_plus_test
+        run: dart run melos run test:flutter
 
   test_web:
     name: Dart Web Test
@@ -135,11 +128,12 @@ jobs:
         run: bash tool/build_wasm.sh
       - name: Serve isar.wasm
         run: npx --yes serve --cors -p 3000 &
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Run Dart Unit tests
-        run: dart test -p chrome
-        working-directory: packages/isar_plus_test
+        run: dart run melos run test:web
 
   coverage:
     name: Code Coverage
@@ -165,18 +159,10 @@ jobs:
         run: sh tool/build.sh
       - name: Build WASM
         run: bash tool/build_wasm.sh
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
-      - name: Add packages
-        run: |
-          flutter pub add json_annotation
-          echo "" >> pubspec.yaml
-          echo "dependency_overrides:" >> pubspec.yaml
-          echo "  isar_plus_flutter_libs:" >> pubspec.yaml
-          echo "    path: ../isar_plus_flutter_libs" >> pubspec.yaml
-          flutter pub add isar_plus_test --path ../isar_plus_test
-          flutter pub get
-        working-directory: packages/isar_plus
+        run: dart run melos run test:prepare
       - name: Collect isar_plus_test Coverage (Native)
         run: |
           flutter test --coverage ../isar_plus_test/test --coverage-path lcov_isar_plus_test.info
@@ -234,11 +220,10 @@ jobs:
           cache: true
       - name: Enable Swift Package Manager
         run: flutter config --enable-swift-package-manager
+      - name: Bootstrap
+        run: flutter pub get
       - name: Run Generator Unit tests
-        run: |
-          dart pub get
-          dart test
-        working-directory: packages/isar_plus
+        run: dart run melos run test:unit
 
   integration_test_chrome:
     name: Integration Test Chrome
@@ -268,13 +253,12 @@ jobs:
         uses: nanasess/setup-chromedriver@v2
       - name: Prepare chromedricer
         run: chromedriver --port=4444 &
+      - name: Bootstrap
+        run: flutter pub get
+      - name: Prepare Tests
+        run: dart run melos run test:prepare
       - name: Run Dart tests in browser
-        run: |
-          flutter pub get
-          dart tool/generate_long_double_test.dart
-          dart tool/generate_all_tests.dart
-          flutter pub run build_runner build
-          flutter drive --driver=integration_driver.dart  --target=integration_test/isar_test.dart -d web-server --browser-name chrome
+        run: flutter drive --driver=integration_driver.dart  --target=integration_test/isar_test.dart -d web-server --browser-name chrome
         working-directory: packages/isar_plus_test
 
   integration_test_firefox:
@@ -307,13 +291,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare geckodriver
         run: geckodriver --port=4444 &
+      - name: Bootstrap
+        run: flutter pub get
+      - name: Prepare Tests
+        run: dart run melos run test:prepare
       - name: Run Dart tests in browser
-        run: |
-          flutter pub get
-          dart tool/generate_long_double_test.dart
-          flutter pub run build_runner build
-          dart tool/generate_all_tests.dart
-          flutter drive --driver=integration_driver.dart --target=integration_test/isar_test.dart -d web-server --browser-name firefox
+        run: flutter drive --driver=integration_driver.dart --target=integration_test/isar_test.dart -d web-server --browser-name firefox
         working-directory: packages/isar_plus_test
 
   integration_test_safari:
@@ -346,13 +329,12 @@ jobs:
         run: |
           sudo safaridriver --enable
           safaridriver --port=4444 &
+      - name: Bootstrap
+        run: flutter pub get
+      - name: Prepare Tests
+        run: dart run melos run test:prepare
       - name: Run Dart tests in browser
-        run: |
-          flutter pub get
-          dart tool/generate_long_double_test.dart
-          flutter pub run build_runner build
-          dart tool/generate_all_tests.dart
-          flutter drive --driver=integration_driver.dart --target=integration_test/isar_test.dart -d web-server --browser-name safari
+        run: flutter drive --driver=integration_driver.dart --target=integration_test/isar_test.dart -d web-server --browser-name safari
         working-directory: packages/isar_plus_test
 
   integration_test_android:
@@ -387,8 +369,10 @@ jobs:
           bash tool/build_android.sh x64
           mkdir -p packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64
           mv libisar_plus_android_x64.so packages/isar_plus_flutter_libs/android/src/main/jniLibs/x86_64/libisar_plus.so
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Free Disk Space
         run: |
           sudo rm -rf /usr/share/dotnet
@@ -429,8 +413,10 @@ jobs:
           path: .
       - name: Extract XCFramework
         run: unzip -o isar_plus_core.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Run Flutter Driver tests
         run: |
           flutter config --enable-macos-desktop
@@ -478,8 +464,10 @@ jobs:
         run: |
           bash tool/build_linux.sh x64
           mv libisar_plus_linux_x64.so packages/isar_plus_flutter_libs/linux/libisar_plus.so
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Run Flutter Driver tests
         run: |
           flutter config --enable-linux-desktop 
@@ -503,8 +491,10 @@ jobs:
         run: |
           bash tool/build_windows.sh x64
           mv isar_plus_windows_x64.dll packages/isar_plus_flutter_libs/windows/isar_plus.dll
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
       - name: Run Flutter Driver tests
         run: |
           flutter config --enable-windows-desktop 
@@ -559,8 +549,10 @@ jobs:
           unzip -o isar_plus_core.xcframework.zip -d packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
           ls -lh packages/isar_plus_flutter_libs/darwin/isar_plus_flutter_libs/Core/
 
+      - name: Bootstrap
+        run: flutter pub get
       - name: Prepare Tests
-        run: sh tool/prepare_tests.sh
+        run: dart run melos run test:prepare
 
       - name: Free Disk Space
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 build/
 **/pubspec_overrides.yaml
 
+# Melos
+.melos_tool/
+
 # Rust related
 target/
 *.a

--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -69,9 +69,8 @@ class _CounterScreenState extends State<CounterScreen> {
 
   Future<void> _initializeDatabase() async {
     try {
-      final directory = kIsWeb
-          ? null
-          : await getApplicationDocumentsDirectory();
+      final directory =
+          kIsWeb ? null : await getApplicationDocumentsDirectory();
       final isar = Isar.open(
         schemas: [CountSchema],
         directory: directory?.path ?? 'isar_data',

--- a/examples/counter/lib/main.g.dart
+++ b/examples/counter/lib/main.g.dart
@@ -60,10 +60,8 @@ Count deserializeCount(IsarReader reader) {
     final objectReader = IsarCore.readObject(reader, 2);
     if (objectReader.isNull) {
       _metadata = StepMetadata(
-        recordedAt: DateTime.fromMillisecondsSinceEpoch(
-          0,
-          isUtc: true,
-        ).toLocal(),
+        recordedAt:
+            DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal(),
       );
     } else {
       final embedded = deserializeStepMetadata(objectReader);
@@ -87,10 +85,8 @@ dynamic deserializeCountProp(IsarReader reader, int property) {
         final objectReader = IsarCore.readObject(reader, 2);
         if (objectReader.isNull) {
           return StepMetadata(
-            recordedAt: DateTime.fromMillisecondsSinceEpoch(
-              0,
-              isUtc: true,
-            ).toLocal(),
+            recordedAt:
+                DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal(),
           );
         } else {
           final embedded = deserializeStepMetadata(objectReader);
@@ -476,15 +472,11 @@ StepMetadata deserializeStepMetadata(IsarReader reader) {
   {
     final value = IsarCore.readLong(reader, 1);
     if (value == -9223372036854775808) {
-      _recordedAt = DateTime.fromMillisecondsSinceEpoch(
-        0,
-        isUtc: true,
-      ).toLocal();
+      _recordedAt =
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal();
     } else {
-      _recordedAt = DateTime.fromMicrosecondsSinceEpoch(
-        value,
-        isUtc: true,
-      ).toLocal();
+      _recordedAt =
+          DateTime.fromMicrosecondsSinceEpoch(value, isUtc: true).toLocal();
     }
   }
   final String _note;

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -1,4 +1,5 @@
 name: counter
+resolution: workspace
 publish_to: "none"
 
 environment:
@@ -7,15 +8,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  isar_plus: 1.3.1
-  isar_plus_flutter_libs: 1.3.1
+  isar_plus: 0.0.0-placeholder
+  isar_plus_flutter_libs: 0.0.0-placeholder
   path_provider: ^2.1.5
 
 dev_dependencies:
   build_runner: ^2.10.2
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/examples/pub/lib/asset_loader.dart
+++ b/examples/pub/lib/asset_loader.dart
@@ -56,10 +56,7 @@ Future<void> loadAssets(PackageAndVersion p) async {
 
   if (readme != null || changelog != null) {
     isar.write((isar) {
-      isar.assets.putAll([
-        if (readme != null) readme,
-        if (changelog != null) changelog,
-      ]);
+      isar.assets.putAll([?readme, ?changelog]);
     });
   }
 }

--- a/examples/pub/pubspec.yaml
+++ b/examples/pub/pubspec.yaml
@@ -1,4 +1,5 @@
 name: pub_app
+resolution: workspace
 description: A new Flutter project.
 publish_to: "none"
 version: 1.0.0+1
@@ -17,8 +18,8 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^3.0.3
   google_fonts: ^6.3.2
-  isar_plus: ^1.1.5
-  isar_plus_flutter_libs: ^1.0.22
+  isar_plus: 0.0.0-placeholder
+  isar_plus_flutter_libs: 0.0.0-placeholder
   json_annotation: ^4.9.0
   markdown: ^7.1.1
   pub_semver: ^2.1.4
@@ -38,7 +39,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.13.0
   json_serializable: ^6.7.1
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 
 flutter:

--- a/examples/pub/pubspec_overrides.yaml
+++ b/examples/pub/pubspec_overrides.yaml
@@ -1,5 +1,0 @@
-dependency_overrides:
-  isar_plus:
-    path: ../../packages/isar_plus
-  isar_plus_flutter_libs:
-    path: ../../packages/isar_plus_flutter_libs

--- a/packages/isar_plus/lib/src/generator/code_gen/collection_schema_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/collection_schema_generator.dart
@@ -24,10 +24,11 @@ String _generateSchema(ObjectInfo object) {
   final embeddedSchemas = object.embeddedDartNames
       .map((e) => '${e.capitalize()}Schema')
       .join(',');
-  final properties = object.properties
-      .where((e) => !e.isId || e.type != IsarType.long)
-      .map(generatePropertySchema)
-      .join();
+  final properties =
+      object.properties
+          .where((e) => !e.isId || e.type != IsarType.long)
+          .map(generatePropertySchema)
+          .join();
   final indexes = object.indexes.map(generateIndexSchema).join();
   return '''
     final ${object.dartName.capitalize()}Schema = IsarGeneratedSchema(

--- a/packages/isar_plus/lib/src/generator/code_gen/deserialize_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/deserialize_generator.dart
@@ -15,10 +15,10 @@ String _generateDeserialize(ObjectInfo object) {
     propertiesByMode[property.mode]!.add(property);
   }
 
-  final positional = propertiesByMode[DeserializeMode.positionalParam]!
-    ..sort(
-      (p1, p2) => p1.constructorPosition!.compareTo(p2.constructorPosition!),
-    );
+  final positional =
+      propertiesByMode[DeserializeMode.positionalParam]!..sort(
+        (p1, p2) => p1.constructorPosition!.compareTo(p2.constructorPosition!),
+      );
   final named = propertiesByMode[DeserializeMode.namedParam]!;
 
   for (final p in [...positional, ...named]) {

--- a/packages/isar_plus/lib/src/generator/code_gen/query_distinct_by_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/query_distinct_by_generator.dart
@@ -5,16 +5,14 @@ String _generateDistinctBy(ObjectInfo oi) {
   extension ${oi.dartName}QueryWhereDistinct on QueryBuilder<${oi.dartName}, ${oi.dartName}, QDistinct> {''';
   for (final property in oi.properties.where((e) => !e.isId)) {
     if (property.type == IsarType.string) {
-      code +=
-          '''
+      code += '''
         QueryBuilder<${oi.dartName}, ${oi.dartName}, QAfterDistinct>distinctBy${property.dartName.capitalize()}({bool caseSensitive = true}) {
           return QueryBuilder.apply(this, (query) {
             return query.addDistinctBy(${property.index}, caseSensitive: caseSensitive);
           });
         }''';
     } else if (!property.type.isObject) {
-      code +=
-          '''
+      code += '''
         QueryBuilder<${oi.dartName}, ${oi.dartName}, QAfterDistinct>distinctBy${property.dartName.capitalize()}() {
           return QueryBuilder.apply(this, (query) {
             return query.addDistinctBy(${property.index});

--- a/packages/isar_plus/lib/src/generator/code_gen/query_sort_by_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/query_sort_by_generator.dart
@@ -13,12 +13,10 @@ String _generateSortBy(ObjectInfo oi) {
       continue;
     }
 
-    final caseSensitiveParam = property.type.isString
-        ? '{bool caseSensitive = true}'
-        : '';
-    final caseSensitiveArg = property.type.isString
-        ? ', caseSensitive: caseSensitive,'
-        : '';
+    final caseSensitiveParam =
+        property.type.isString ? '{bool caseSensitive = true}' : '';
+    final caseSensitiveArg =
+        property.type.isString ? ', caseSensitive: caseSensitive,' : '';
 
     buffer.write('''
     ${prefix}sortBy${property.dartName.capitalize()}($caseSensitiveParam) {
@@ -46,12 +44,10 @@ String _generateSortBy(ObjectInfo oi) {
       continue;
     }
 
-    final caseSensitiveParam = property.type.isString
-        ? '{bool caseSensitive = true}'
-        : '';
-    final caseSensitiveArg = property.type.isString
-        ? ', caseSensitive: caseSensitive'
-        : '';
+    final caseSensitiveParam =
+        property.type.isString ? '{bool caseSensitive = true}' : '';
+    final caseSensitiveArg =
+        property.type.isString ? ', caseSensitive: caseSensitive' : '';
 
     buffer.write('''
     ${prefix}thenBy${property.dartName.capitalize()}($caseSensitiveParam) {

--- a/packages/isar_plus/lib/src/generator/code_gen/serialize_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/serialize_generator.dart
@@ -49,11 +49,12 @@ String _writeProperty({
   String writer = 'writer',
   bool? elementNullable,
 }) {
-  final enumGetter = enumProperty != null
-      ? nullable
-            ? '?.$enumProperty'
-            : '.$enumProperty'
-      : '';
+  final enumGetter =
+      enumProperty != null
+          ? nullable
+              ? '?.$enumProperty'
+              : '.$enumProperty'
+          : '';
   switch (type) {
     case IsarType.bool:
       if (nullable) {
@@ -81,10 +82,11 @@ String _writeProperty({
       final orNull = nullable ? '?? $_nullLong' : '';
       return 'IsarCore.writeLong($writer, $index, $value$enumGetter $orNull);';
     case IsarType.dateTime:
-      final converted = nullable
-          ? '$value$enumGetter?.toUtc().microsecondsSinceEpoch '
-                '?? $_nullLong'
-          : '$value$enumGetter.toUtc().microsecondsSinceEpoch';
+      final converted =
+          nullable
+              ? '$value$enumGetter?.toUtc().microsecondsSinceEpoch '
+                  '?? $_nullLong'
+              : '$value$enumGetter.toUtc().microsecondsSinceEpoch';
       return 'IsarCore.writeLong($writer, $index, $converted);';
     case IsarType.double:
       final orNull = nullable ? '?? double.nan' : '';
@@ -109,14 +111,12 @@ String _writeProperty({
       {
         final value = $value;''';
       if (nullable) {
-        code +=
-            '''
+        code += '''
         if (value == null) {
           IsarCore.writeNull($writer, $index);
         } else {''';
       }
-      code +=
-          '''
+      code += '''
       final objectWriter = IsarCore.beginObject($writer, $index);
       serialize$typeClassName(objectWriter, value);
       IsarCore.endObject($writer, objectWriter);''';
@@ -139,14 +139,12 @@ String _writeProperty({
       {
         final list = $value;''';
       if (nullable) {
-        code +=
-            '''
+        code += '''
         if (list == null) {
           IsarCore.writeNull($writer, $index);
         } else {''';
       }
-      code +=
-          '''
+      code += '''
       final listWriter = IsarCore.beginList(writer, $index, list.length);
       for (var i = 0; i < list.length; i++) {
         ${_writeProperty(writer: 'listWriter', index: 'i', type: type.scalarType, nullable: elementNullable!, typeClassName: typeClassName, value: 'list[i]', enumProperty: enumProperty)}

--- a/packages/isar_plus/lib/src/generator/code_gen/update_generator.dart
+++ b/packages/isar_plus/lib/src/generator/code_gen/update_generator.dart
@@ -12,9 +12,10 @@ const List<IsarType> _updateableTypes = [
 ];
 
 String _generateUpdate(ObjectInfo oi) {
-  final updateProperties = oi.properties
-      .where((p) => !p.isId && _updateableTypes.contains(p.type))
-      .toList();
+  final updateProperties =
+      oi.properties
+          .where((p) => !p.isId && _updateableTypes.contains(p.type))
+          .toList();
 
   if (updateProperties.isEmpty) {
     return '';

--- a/packages/isar_plus/lib/src/generator/collection_generator.dart
+++ b/packages/isar_plus/lib/src/generator/collection_generator.dart
@@ -23,9 +23,8 @@ class _IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {
     BuildStep buildStep,
   ) async {
     final object = _IsarAnalyzer().analyzeCollection(element);
-    final idType = object.idProperty!.type == IsarType.string
-        ? 'String'
-        : 'int';
+    final idType =
+        object.idProperty!.type == IsarType.string ? 'String' : 'int';
     return '''
       // coverage:ignore-file
       // ignore_for_file: ${_ignoreLints.join(', ')}

--- a/packages/isar_plus/lib/src/generator/helper.dart
+++ b/packages/isar_plus/lib/src/generator/helper.dart
@@ -56,11 +56,12 @@ extension on PropertyInducingElement {
     return _indexChecker.annotationsOfExact(nonSynthetic).map((ann) {
       return Index(
         name: ann.getField('name')!.toStringValue(),
-        composite: ann
-            .getField('composite')!
-            .toListValue()!
-            .map((e) => e.toStringValue()!)
-            .toList(),
+        composite:
+            ann
+                .getField('composite')!
+                .toListValue()!
+                .map((e) => e.toStringValue()!)
+                .toList(),
         unique: ann.getField('unique')!.toBoolValue()!,
         hash: ann.getField('hash')!.toBoolValue()!,
       );
@@ -70,10 +71,11 @@ extension on PropertyInducingElement {
 
 extension on EnumElement {
   FieldElement? get enumValueProperty {
-    final annotatedProperties = fields
-        .where((e) => !e.isEnumConstant)
-        .where(_enumPropertyChecker.hasAnnotationOfExact)
-        .toList();
+    final annotatedProperties =
+        fields
+            .where((e) => !e.isEnumConstant)
+            .where(_enumPropertyChecker.hasAnnotationOfExact)
+            .toList();
     if (annotatedProperties.length > 1) {
       _err('Only one property can be annotated with @enumProperty', this);
     } else {
@@ -103,11 +105,12 @@ extension on Element {
     return Collection(
       inheritance: ann.getField('inheritance')!.toBoolValue()!,
       accessor: ann.getField('accessor')!.toStringValue(),
-      ignore: ann
-          .getField('ignore')!
-          .toSetValue()!
-          .map((e) => e.toStringValue()!)
-          .toSet(),
+      ignore:
+          ann
+              .getField('ignore')!
+              .toSetValue()!
+              .map((e) => e.toStringValue()!)
+              .toSet(),
     );
   }
 
@@ -132,11 +135,12 @@ extension on Element {
     }
     return Embedded(
       inheritance: ann.getField('inheritance')!.toBoolValue()!,
-      ignore: ann
-          .getField('ignore')!
-          .toSetValue()!
-          .map((e) => e.toStringValue()!)
-          .toSet(),
+      ignore:
+          ann
+              .getField('ignore')!
+              .toSetValue()!
+              .map((e) => e.toStringValue()!)
+              .toSet(),
     );
   }
 }

--- a/packages/isar_plus/lib/src/generator/isar_analyzer.dart
+++ b/packages/isar_plus/lib/src/generator/isar_analyzer.dart
@@ -152,13 +152,14 @@ class _IsarAnalyzer {
       );
     }
 
-    final unknownConstructorParameter = constructor.formalParameters
-        .where(
-          (p) =>
-              p.isRequired &&
-              !properties.any((e) => e.dartName == (p.name ?? '')),
-        )
-        .firstOrNull;
+    final unknownConstructorParameter =
+        constructor.formalParameters
+            .where(
+              (p) =>
+                  p.isRequired &&
+                  !properties.any((e) => e.dartName == (p.name ?? '')),
+            )
+            .firstOrNull;
     if (unknownConstructorParameter != null) {
       _err(
         'Constructor parameter does not match a property.',
@@ -197,9 +198,8 @@ class _IsarAnalyzer {
     late final IsarType type;
     if (dartType.scalarType.element is EnumElement) {
       final enumClass = dartType.scalarType.element! as EnumElement;
-      final enumElements = enumClass.fields
-          .where((f) => f.isEnumConstant)
-          .toList();
+      final enumElements =
+          enumClass.fields.where((f) => f.isEnumConstant).toList();
 
       final enumProperty = enumClass.enumValueProperty;
       enumPropertyName = enumProperty?.name ?? 'index';
@@ -208,9 +208,8 @@ class _IsarAnalyzer {
         _err('Only fields are supported for enum properties', enumProperty);
       }
 
-      final enumIsarType = enumProperty == null
-          ? IsarType.byte
-          : enumProperty.type.propertyType;
+      final enumIsarType =
+          enumProperty == null ? IsarType.byte : enumProperty.type.propertyType;
       if (enumIsarType != IsarType.byte &&
           enumIsarType != IsarType.int &&
           enumIsarType != IsarType.long &&
@@ -264,10 +263,11 @@ class _IsarAnalyzer {
     final nullable =
         dartType.nullabilitySuffix != NullabilitySuffix.none ||
         dartType is DynamicType;
-    final elementNullable = type.isList
-        ? dartType.scalarType.nullabilitySuffix != NullabilitySuffix.none ||
-              dartType.scalarType is DynamicType
-        : null;
+    final elementNullable =
+        type.isList
+            ? dartType.scalarType.nullabilitySuffix != NullabilitySuffix.none ||
+                dartType.scalarType is DynamicType
+            : null;
     if (isId) {
       if (type != IsarType.long && type != IsarType.string) {
         _err('Only int and String properties can be used as id.', property);
@@ -281,9 +281,10 @@ class _IsarAnalyzer {
       _err('Bytes must not be nullable.', property);
     }
 
-    final constructorParameter = constructor.formalParameters
-        .where((p) => (p.name ?? '') == property.name)
-        .firstOrNull;
+    final constructorParameter =
+        constructor.formalParameters
+            .where((p) => (p.name ?? '') == property.name)
+            .firstOrNull;
     int? constructorPosition;
     late DeserializeMode mode;
     if (constructorParameter != null) {
@@ -293,28 +294,30 @@ class _IsarAnalyzer {
           constructorParameter,
         );
       }
-      mode = constructorParameter.isNamed
-          ? DeserializeMode.namedParam
-          : DeserializeMode.positionalParam;
+      mode =
+          constructorParameter.isNamed
+              ? DeserializeMode.namedParam
+              : DeserializeMode.positionalParam;
       constructorPosition = constructor.formalParameters.indexOf(
         constructorParameter,
       );
     } else {
-      mode = property.setter == null
-          ? DeserializeMode.none
-          : DeserializeMode.assign;
+      mode =
+          property.setter == null
+              ? DeserializeMode.none
+              : DeserializeMode.assign;
     }
 
     return PropertyInfo(
       index: propertyIndex,
       dartName: property.name ?? '',
       isarName: property.isarName,
-      typeClassName: type == IsarType.json
-          ? dartType.element!.name!
-          : dartType.scalarType.element!.name!,
-      targetIsarName: type.isObject
-          ? dartType.scalarType.element!.isarName
-          : null,
+      typeClassName:
+          type == IsarType.json
+              ? dartType.element!.name!
+              : dartType.scalarType.element!.name!,
+      targetIsarName:
+          type.isObject ? dartType.scalarType.element!.isarName : null,
       type: type,
       isId: isId,
       enumMap: enumMap,
@@ -323,9 +326,8 @@ class _IsarAnalyzer {
       elementNullable: elementNullable,
       defaultValue:
           constructorParameter?.defaultValueCode ?? _defaultValue(dartType),
-      elementDefaultValue: type.isList
-          ? _defaultValue(dartType.scalarType)
-          : null,
+      elementDefaultValue:
+          type.isList ? _defaultValue(dartType.scalarType) : null,
       utc: type.isDate && property.hasUtcAnnotation,
       mode: mode,
       assignable: property.setter != null,
@@ -396,9 +398,8 @@ class _IsarAnalyzer {
 
       for (var i = 0; i < indexProperties.length; i++) {
         final propertyName = indexProperties[i];
-        final property = properties
-            .where((it) => it.isarName == propertyName)
-            .firstOrNull;
+        final property =
+            properties.where((it) => it.isarName == propertyName).firstOrNull;
         if (property == null) {
           _err('Property does not exist: "$propertyName".', element);
         } else if (property.isId) {

--- a/packages/isar_plus/lib/src/generator/object_info.dart
+++ b/packages/isar_plus/lib/src/generator/object_info.dart
@@ -225,9 +225,10 @@ class PropertyInfo {
   }
 
   /// The full Dart type of the property.
-  String get dartType => type.isList
-      ? 'List<$scalarDartType>${nullable ? '?' : ''}'
-      : scalarDartType;
+  String get dartType =>
+      type.isList
+          ? 'List<$scalarDartType>${nullable ? '?' : ''}'
+          : scalarDartType;
 
   /// Generates the enum map name for this property.
   String enumMapName(ObjectInfo object) =>

--- a/packages/isar_plus/lib/src/isar_connect.dart
+++ b/packages/isar_plus/lib/src/isar_connect.dart
@@ -47,9 +47,10 @@ abstract class _IsarConnect {
     for (final handler in _handlers.entries) {
       registerExtension(handler.key.method, (method, parameters) async {
         try {
-          final args = parameters.containsKey('args')
-              ? jsonDecode(parameters['args']!) as Map<String, dynamic>
-              : <String, dynamic>{};
+          final args =
+              parameters.containsKey('args')
+                  ? jsonDecode(parameters['args']!) as Map<String, dynamic>
+                  : <String, dynamic>{};
           final result = <String, dynamic>{'result': await handler.value(args)};
           return ServiceExtensionResponse.result(jsonEncode(result));
         } on Exception catch (e) {
@@ -87,8 +88,7 @@ abstract class _IsarConnect {
           return left.join() + text + right.join();
         }
 
-        final message =
-            '''
+        final message = '''
       ╔${line('', '═')}╗
       ║${line('ISAR CONNECT STARTED', ' ')}║
       ╟${line('', '─')}╢

--- a/packages/isar_plus/lib/src/isar_connect_api.dart
+++ b/packages/isar_plus/lib/src/isar_connect_api.dart
@@ -131,9 +131,10 @@ class ConnectQueryPayload {
     return ConnectQueryPayload(
       instance: json['instance'] as String,
       collection: json['collection'] as String,
-      filter: json['filter'] != null
-          ? _filterFromJson(json['filter'] as Map<String, dynamic>)
-          : null,
+      filter:
+          json['filter'] != null
+              ? _filterFromJson(json['filter'] as Map<String, dynamic>)
+              : null,
       offset: json['offset'] as int?,
       limit: json['limit'] as int?,
       sortProperty: json['sortProperty'] as int?,

--- a/packages/isar_plus/lib/src/isar_schema.dart
+++ b/packages/isar_plus/lib/src/isar_schema.dart
@@ -20,12 +20,16 @@ class IsarSchema {
       name: json['name'] as String,
       idName: json['idName'] as String?,
       embedded: json['embedded'] as bool,
-      properties: (json['properties'] as List<dynamic>)
-          .map((e) => IsarPropertySchema.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      indexes: (json['indexes'] as List<dynamic>)
-          .map((e) => IsarIndexSchema.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      properties:
+          (json['properties'] as List<dynamic>)
+              .map(
+                (e) => IsarPropertySchema.fromJson(e as Map<String, dynamic>),
+              )
+              .toList(),
+      indexes:
+          (json['indexes'] as List<dynamic>)
+              .map((e) => IsarIndexSchema.fromJson(e as Map<String, dynamic>))
+              .toList(),
     );
   }
 

--- a/packages/isar_plus/lib/src/watcher_details.dart
+++ b/packages/isar_plus/lib/src/watcher_details.dart
@@ -390,14 +390,15 @@ class ChangeDetail<T extends DocumentSerializable> {
   /// Provides detailed string representation for debugging and logging.
   @override
   String toString() {
-    final buffer = StringBuffer()
-      ..write('ChangeDetail<$T>(')
-      ..write('collection: $collectionName, ')
-      ..write('id: $objectId, ')
-      ..write('type: $changeType, ')
-      ..write('timestamp: ${timestamp?.toIso8601String()}, ')
-      ..write('fieldChanges: ${fieldChanges.length}')
-      ..write(')');
+    final buffer =
+        StringBuffer()
+          ..write('ChangeDetail<$T>(')
+          ..write('collection: $collectionName, ')
+          ..write('id: $objectId, ')
+          ..write('type: $changeType, ')
+          ..write('timestamp: ${timestamp?.toIso8601String()}, ')
+          ..write('fieldChanges: ${fieldChanges.length}')
+          ..write(')');
 
     return buffer.toString();
   }

--- a/packages/isar_plus/pubspec.yaml
+++ b/packages/isar_plus/pubspec.yaml
@@ -1,4 +1,5 @@
 name: isar_plus
+resolution: workspace
 description: Extremely fast, easy to use, and fully async NoSQL database for Flutter. Enhanced version with additional features.
 version: 0.0.0-placeholder
 repository: https://github.com/ahmtydn/isar_plus/tree/main/packages/isar_plus
@@ -32,5 +33,5 @@ dev_dependencies:
   build_test: ^3.5.15
   ffigen: ^20.1.1
   flutter_lints: ^6.0.0
-  test: ^1.31.1
+  test: ">=1.24.0 <2.0.0"
   very_good_analysis: ^10.2.0

--- a/packages/isar_plus_flutter_libs/pubspec.yaml
+++ b/packages/isar_plus_flutter_libs/pubspec.yaml
@@ -1,11 +1,12 @@
 name: isar_plus_flutter_libs
+resolution: workspace
 description: Isar Plus Core binaries for the Isar Plus Database. Needs to be included for Flutter apps.
 version: 0.0.0-placeholder
 repository: https://github.com/ahmtydn/isar
 homepage: https://github.com/ahmtydn/isar
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"
 
 dependencies:

--- a/packages/isar_plus_flutter_libs/pubspec_overrides.yaml
+++ b/packages/isar_plus_flutter_libs/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  isar_plus: 
-    path: ../isar_plus

--- a/packages/isar_plus_inspector/lib/collection/collection_area.dart
+++ b/packages/isar_plus_inspector/lib/collection/collection_area.dart
@@ -302,10 +302,11 @@ class _CollectionAreaState extends State<CollectionArea> {
     final data = await widget.client.exportJson(query);
     try {
       final base64Data = base64Encode(utf8.encode(jsonEncode(data)));
-      final anchor = web.document.createElement('a') as web.HTMLAnchorElement
-        ..href = 'data:application/octet-stream;base64,$base64Data'
-        ..target = '_blank'
-        ..download = '${widget.collection}.json';
+      final anchor =
+          web.document.createElement('a') as web.HTMLAnchorElement
+            ..href = 'data:application/octet-stream;base64,$base64Data'
+            ..target = '_blank'
+            ..download = '${widget.collection}.json';
 
       web.document.body?.appendChild(anchor);
       anchor.click();

--- a/packages/isar_plus_inspector/lib/collections_list.dart
+++ b/packages/isar_plus_inspector/lib/collections_list.dart
@@ -31,12 +31,13 @@ class CollectionsList extends StatelessWidget {
         return Padding(
           padding: const EdgeInsets.only(bottom: 10),
           child: ElevatedButton(
-            style: collection.name == selectedCollection
-                ? ElevatedButton.styleFrom(
-                    backgroundColor: theme.colorScheme.primaryContainer,
-                    foregroundColor: theme.colorScheme.onPrimaryContainer,
-                  )
-                : null,
+            style:
+                collection.name == selectedCollection
+                    ? ElevatedButton.styleFrom(
+                      backgroundColor: theme.colorScheme.primaryContainer,
+                      foregroundColor: theme.colorScheme.onPrimaryContainer,
+                    )
+                    : null,
             onPressed: () {
               onSelected(collection.name);
             },

--- a/packages/isar_plus_inspector/lib/common/confirm_delete_dialog.dart
+++ b/packages/isar_plus_inspector/lib/common/confirm_delete_dialog.dart
@@ -4,34 +4,35 @@ import 'package:flutter/material.dart';
 Future<bool?> showConfirmDeleteDialog(BuildContext context, String message) {
   return showDialog<bool>(
     context: context,
-    builder: (context) => AlertDialog(
-      title: Row(
-        children: [
-          Icon(
-            Icons.warning_amber_rounded,
-            color: Colors.orange[700],
-            size: 24,
+    builder:
+        (context) => AlertDialog(
+          title: Row(
+            children: [
+              Icon(
+                Icons.warning_amber_rounded,
+                color: Colors.orange[700],
+                size: 24,
+              ),
+              const SizedBox(width: 8),
+              const Text('Confirm Delete'),
+            ],
           ),
-          const SizedBox(width: 8),
-          const Text('Confirm Delete'),
-        ],
-      ),
-      content: Text(message),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('Cancel'),
+          content: Text(message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton.icon(
+              onPressed: () => Navigator.of(context).pop(true),
+              icon: const Icon(Icons.delete_outline, size: 18),
+              label: const Text('Delete'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red[700],
+                foregroundColor: Colors.white,
+              ),
+            ),
+          ],
         ),
-        ElevatedButton.icon(
-          onPressed: () => Navigator.of(context).pop(true),
-          icon: const Icon(Icons.delete_outline, size: 18),
-          label: const Text('Delete'),
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.red[700],
-            foregroundColor: Colors.white,
-          ),
-        ),
-      ],
-    ),
   );
 }

--- a/packages/isar_plus_inspector/lib/connected_layout.dart
+++ b/packages/isar_plus_inspector/lib/connected_layout.dart
@@ -66,10 +66,8 @@ class _ConnectedLayoutState extends State<ConnectedLayout> {
           if (mounted && selectedInstance == instance) {
             setState(() {
               schemas.addAll(newSchemas);
-              selectedCollection = schemas
-                  .where((e) => !e.embedded)
-                  .firstOrNull
-                  ?.name;
+              selectedCollection =
+                  schemas.where((e) => !e.embedded).firstOrNull?.name;
             });
           }
         }),

--- a/packages/isar_plus_inspector/lib/instance_selector.dart
+++ b/packages/isar_plus_inspector/lib/instance_selector.dart
@@ -82,9 +82,10 @@ class _InstanceSelectorState extends State<InstanceSelector>
               SelectedInstanceButton(
                 instance: widget.selectedInstance!,
                 hasMultiple: widget.instances.length > 1,
-                color: _animation.status != AnimationStatus.dismissed
-                    ? Colors.blue
-                    : null,
+                color:
+                    _animation.status != AnimationStatus.dismissed
+                        ? Colors.blue
+                        : null,
                 onTap: () {
                   if (_controller.status == AnimationStatus.completed) {
                     unawaited(_controller.reverse());

--- a/packages/isar_plus_inspector/lib/main.dart
+++ b/packages/isar_plus_inspector/lib/main.dart
@@ -57,9 +57,10 @@ class App extends StatelessWidget {
       theme: ThemeData.from(
         colorScheme: ColorScheme.fromSeed(
           seedColor: const Color(0xFF9FC9FF),
-          brightness: DarkMode.of(context).darkMode
-              ? Brightness.dark
-              : Brightness.light,
+          brightness:
+              DarkMode.of(context).darkMode
+                  ? Brightness.dark
+                  : Brightness.light,
         ),
         useMaterial3: true,
       ),

--- a/packages/isar_plus_inspector/lib/object/property_builder.dart
+++ b/packages/isar_plus_inspector/lib/object/property_builder.dart
@@ -34,9 +34,10 @@ class _PropertyBuilderState extends State<PropertyBuilder> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         InkWell(
-          onTap: widget.children.isNotEmpty
-              ? () => setState(() => _expanded = !_expanded)
-              : null,
+          onTap:
+              widget.children.isNotEmpty
+                  ? () => setState(() => _expanded = !_expanded)
+                  : null,
           customBorder: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20),
           ),
@@ -64,9 +65,8 @@ class _PropertyBuilderState extends State<PropertyBuilder> {
                     style: GoogleFonts.jetBrainsMono(
                       fontWeight: widget.bold ? FontWeight.w800 : null,
                       color: theme.colorScheme.onPrimaryContainer,
-                      decoration: widget.underline
-                          ? TextDecoration.underline
-                          : null,
+                      decoration:
+                          widget.underline ? TextDecoration.underline : null,
                     ),
                   ),
                 ),

--- a/packages/isar_plus_inspector/lib/object/property_json_value.dart
+++ b/packages/isar_plus_inspector/lib/object/property_json_value.dart
@@ -59,9 +59,10 @@ class _NullJsonValue extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onUpdate == null
-          ? null
-          : () => _showJsonEditor(context, null, onUpdate!),
+      onTap:
+          onUpdate == null
+              ? null
+              : () => _showJsonEditor(context, null, onUpdate!),
       child: Text(
         'null',
         style: GoogleFonts.jetBrainsMono(
@@ -86,9 +87,10 @@ class _StringJsonValue extends StatefulWidget {
 
 class _StringJsonValueState extends State<_StringJsonValue> {
   late final controller = TextEditingController(
-    text: widget.value.length > 50
-        ? '"${widget.value.substring(0, 47)}..."'
-        : '"${widget.value}"',
+    text:
+        widget.value.length > 50
+            ? '"${widget.value.substring(0, 47)}..."'
+            : '"${widget.value}"',
   );
 
   @override
@@ -100,9 +102,10 @@ class _StringJsonValueState extends State<_StringJsonValue> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: widget.onUpdate == null
-          ? null
-          : () => _showJsonEditor(context, widget.value, widget.onUpdate!),
+      onTap:
+          widget.onUpdate == null
+              ? null
+              : () => _showJsonEditor(context, widget.value, widget.onUpdate!),
       child: Tooltip(
         message: widget.value.length > 50 ? widget.value : '',
         child: Text(
@@ -246,25 +249,26 @@ class _BoolJsonValue extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: onUpdate == null
-          ? null
-          : (details) async {
-              final newValue = await showMenu(
-                context: context,
-                position: RelativeRect.fromLTRB(
-                  details.globalPosition.dx,
-                  details.globalPosition.dy,
-                  100000,
-                  0,
-                ),
-                items: const [
-                  PopupMenuItem<bool?>(value: true, child: Text('true')),
-                  PopupMenuItem<bool?>(value: false, child: Text('false')),
-                  PopupMenuItem<bool?>(child: Text('null')),
-                ],
-              );
-              onUpdate?.call(newValue);
-            },
+      onTapDown:
+          onUpdate == null
+              ? null
+              : (details) async {
+                final newValue = await showMenu(
+                  context: context,
+                  position: RelativeRect.fromLTRB(
+                    details.globalPosition.dx,
+                    details.globalPosition.dy,
+                    100000,
+                    0,
+                  ),
+                  items: const [
+                    PopupMenuItem<bool?>(value: true, child: Text('true')),
+                    PopupMenuItem<bool?>(value: false, child: Text('false')),
+                    PopupMenuItem<bool?>(child: Text('null')),
+                  ],
+                );
+                onUpdate?.call(newValue);
+              },
       child: Text(
         value.toString(),
         style: GoogleFonts.jetBrainsMono(
@@ -321,8 +325,12 @@ class _MapJsonValueState extends State<_MapJsonValue> {
             if (widget.onUpdate != null) ...[
               const SizedBox(width: 8),
               InkWell(
-                onTap: () =>
-                    _showAddMapEntry(context, widget.value, widget.onUpdate!),
+                onTap:
+                    () => _showAddMapEntry(
+                      context,
+                      widget.value,
+                      widget.onUpdate!,
+                    ),
                 child: Icon(
                   Icons.add_circle_outline,
                   size: 16,
@@ -391,11 +399,12 @@ class _MapJsonValueState extends State<_MapJsonValue> {
                   const Spacer(),
                   if (widget.onUpdate != null) ...[
                     InkWell(
-                      onTap: () => _showAddMapEntry(
-                        context,
-                        widget.value,
-                        widget.onUpdate!,
-                      ),
+                      onTap:
+                          () => _showAddMapEntry(
+                            context,
+                            widget.value,
+                            widget.onUpdate!,
+                          ),
                       child: Padding(
                         padding: const EdgeInsets.all(4),
                         child: Icon(
@@ -407,11 +416,12 @@ class _MapJsonValueState extends State<_MapJsonValue> {
                     ),
                     const SizedBox(width: 4),
                     InkWell(
-                      onTap: () => _showJsonEditor(
-                        context,
-                        widget.value,
-                        widget.onUpdate!,
-                      ),
+                      onTap:
+                          () => _showJsonEditor(
+                            context,
+                            widget.value,
+                            widget.onUpdate!,
+                          ),
                       child: Padding(
                         padding: const EdgeInsets.all(4),
                         child: Icon(
@@ -464,19 +474,20 @@ class _MapJsonValueState extends State<_MapJsonValue> {
                   child: PropertyJsonValue(
                     value: entry.value,
                     depth: widget.depth + 1,
-                    onUpdate: widget.onUpdate == null
-                        ? null
-                        : (newValue) {
-                            final updatedMap = Map<String, dynamic>.from(
-                              widget.value,
-                            );
-                            if (newValue == null) {
-                              updatedMap.remove(entry.key);
-                            } else {
-                              updatedMap[entry.key] = newValue;
-                            }
-                            widget.onUpdate?.call(updatedMap);
-                          },
+                    onUpdate:
+                        widget.onUpdate == null
+                            ? null
+                            : (newValue) {
+                              final updatedMap = Map<String, dynamic>.from(
+                                widget.value,
+                              );
+                              if (newValue == null) {
+                                updatedMap.remove(entry.key);
+                              } else {
+                                updatedMap[entry.key] = newValue;
+                              }
+                              widget.onUpdate?.call(updatedMap);
+                            },
                   ),
                 ),
               ],
@@ -484,15 +495,18 @@ class _MapJsonValueState extends State<_MapJsonValue> {
           ),
           if (widget.onUpdate != null)
             InkWell(
-              onTap: () => _confirmDelete(
-                context,
-                'Delete property "${entry.key}"?',
-                () {
-                  final updatedMap = Map<String, dynamic>.from(widget.value);
-                  updatedMap.remove(entry.key);
-                  widget.onUpdate?.call(updatedMap);
-                },
-              ),
+              onTap:
+                  () => _confirmDelete(
+                    context,
+                    'Delete property "${entry.key}"?',
+                    () {
+                      final updatedMap = Map<String, dynamic>.from(
+                        widget.value,
+                      );
+                      updatedMap.remove(entry.key);
+                      widget.onUpdate?.call(updatedMap);
+                    },
+                  ),
               child: Padding(
                 padding: const EdgeInsets.all(4),
                 child: Icon(Icons.close, size: 14, color: Colors.red[300]),
@@ -549,8 +563,12 @@ class _ListJsonValueState extends State<_ListJsonValue> {
             if (widget.onUpdate != null) ...[
               const SizedBox(width: 8),
               InkWell(
-                onTap: () =>
-                    _showAddListItem(context, widget.value, widget.onUpdate!),
+                onTap:
+                    () => _showAddListItem(
+                      context,
+                      widget.value,
+                      widget.onUpdate!,
+                    ),
                 child: Icon(
                   Icons.add_circle_outline,
                   size: 16,
@@ -619,11 +637,12 @@ class _ListJsonValueState extends State<_ListJsonValue> {
                   const Spacer(),
                   if (widget.onUpdate != null) ...[
                     InkWell(
-                      onTap: () => _showAddListItem(
-                        context,
-                        widget.value,
-                        widget.onUpdate!,
-                      ),
+                      onTap:
+                          () => _showAddListItem(
+                            context,
+                            widget.value,
+                            widget.onUpdate!,
+                          ),
                       child: Padding(
                         padding: const EdgeInsets.all(4),
                         child: Icon(
@@ -635,11 +654,12 @@ class _ListJsonValueState extends State<_ListJsonValue> {
                     ),
                     const SizedBox(width: 4),
                     InkWell(
-                      onTap: () => _showJsonEditor(
-                        context,
-                        widget.value,
-                        widget.onUpdate!,
-                      ),
+                      onTap:
+                          () => _showJsonEditor(
+                            context,
+                            widget.value,
+                            widget.onUpdate!,
+                          ),
                       child: Padding(
                         padding: const EdgeInsets.all(4),
                         child: Icon(
@@ -697,27 +717,32 @@ class _ListJsonValueState extends State<_ListJsonValue> {
             child: PropertyJsonValue(
               value: widget.value[index],
               depth: widget.depth + 1,
-              onUpdate: widget.onUpdate == null
-                  ? null
-                  : (newValue) {
-                      final updatedList = List<dynamic>.from(widget.value);
-                      if (newValue == null) {
-                        updatedList.removeAt(index);
-                      } else {
-                        updatedList[index] = newValue;
-                      }
-                      widget.onUpdate?.call(updatedList);
-                    },
+              onUpdate:
+                  widget.onUpdate == null
+                      ? null
+                      : (newValue) {
+                        final updatedList = List<dynamic>.from(widget.value);
+                        if (newValue == null) {
+                          updatedList.removeAt(index);
+                        } else {
+                          updatedList[index] = newValue;
+                        }
+                        widget.onUpdate?.call(updatedList);
+                      },
             ),
           ),
           if (widget.onUpdate != null)
             InkWell(
-              onTap: () =>
-                  _confirmDelete(context, 'Delete item at index $index?', () {
-                    final updatedList = List<dynamic>.from(widget.value);
-                    updatedList.removeAt(index);
-                    widget.onUpdate?.call(updatedList);
-                  }),
+              onTap:
+                  () => _confirmDelete(
+                    context,
+                    'Delete item at index $index?',
+                    () {
+                      final updatedList = List<dynamic>.from(widget.value);
+                      updatedList.removeAt(index);
+                      widget.onUpdate?.call(updatedList);
+                    },
+                  ),
               child: Padding(
                 padding: const EdgeInsets.all(4),
                 child: Icon(Icons.close, size: 14, color: Colors.red[300]),
@@ -738,99 +763,104 @@ void _showJsonEditor(
   final isDark = theme.brightness == Brightness.dark;
 
   final controller = TextEditingController(
-    text: currentValue == null
-        ? ''
-        : const JsonEncoder.withIndent('  ').convert(currentValue),
+    text:
+        currentValue == null
+            ? ''
+            : const JsonEncoder.withIndent('  ').convert(currentValue),
   );
 
   unawaited(
     showDialog<void>(
       context: context,
-      builder: (context) => Theme(
-        data: theme.copyWith(
-          dialogTheme: DialogThemeData(
-            backgroundColor: isDark ? Colors.grey[900] : Colors.white,
-          ),
-        ),
-        child: AlertDialog(
-          title: Row(
-            children: [
-              Icon(Icons.code, color: theme.colorScheme.primary, size: 20),
-              const SizedBox(width: 8),
-              const Text('Edit JSON Value'),
-            ],
-          ),
-          content: SizedBox(
-            width: 700,
-            height: 500,
-            child: Container(
-              decoration: BoxDecoration(
-                color: isDark ? Colors.grey[850] : Colors.grey[100],
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-                ),
-              ),
-              child: TextField(
-                controller: controller,
-                maxLines: null,
-                expands: true,
-                decoration: InputDecoration(
-                  hintText: '{\n  "key": "value"\n}',
-                  hintStyle: GoogleFonts.jetBrainsMono(
-                    color: isDark ? Colors.grey[600] : Colors.grey[400],
-                    fontSize: 13,
-                  ),
-                  border: InputBorder.none,
-                  contentPadding: const EdgeInsets.all(16),
-                ),
-                style: GoogleFonts.jetBrainsMono(
-                  fontSize: 13,
-                  color: isDark ? Colors.green[300] : Colors.green[800],
-                  height: 1.5,
-                ),
+      builder:
+          (context) => Theme(
+            data: theme.copyWith(
+              dialogTheme: DialogThemeData(
+                backgroundColor: isDark ? Colors.grey[900] : Colors.white,
               ),
             ),
-          ),
-          actions: [
-            TextButton.icon(
-              onPressed: () => Navigator.of(context).pop(),
-              icon: const Icon(Icons.close, size: 18),
-              label: const Text('Cancel'),
-            ),
-            ElevatedButton.icon(
-              onPressed: () {
-                try {
-                  final text = controller.text.trim();
-                  if (text.isEmpty) {
-                    onUpdate(null);
-                  } else {
-                    final parsed = jsonDecode(text);
-                    onUpdate(parsed);
-                  }
-                  Navigator.of(context).pop();
-                } on Exception catch (e) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Row(
-                        children: [
-                          const Icon(Icons.error_outline, color: Colors.white),
-                          const SizedBox(width: 8),
-                          Expanded(child: Text('Invalid JSON: $e')),
-                        ],
-                      ),
-                      backgroundColor: Colors.red[700],
-                      behavior: SnackBarBehavior.floating,
+            child: AlertDialog(
+              title: Row(
+                children: [
+                  Icon(Icons.code, color: theme.colorScheme.primary, size: 20),
+                  const SizedBox(width: 8),
+                  const Text('Edit JSON Value'),
+                ],
+              ),
+              content: SizedBox(
+                width: 700,
+                height: 500,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: isDark ? Colors.grey[850] : Colors.grey[100],
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
                     ),
-                  );
-                }
-              },
-              icon: const Icon(Icons.save, size: 18),
-              label: const Text('Save'),
+                  ),
+                  child: TextField(
+                    controller: controller,
+                    maxLines: null,
+                    expands: true,
+                    decoration: InputDecoration(
+                      hintText: '{\n  "key": "value"\n}',
+                      hintStyle: GoogleFonts.jetBrainsMono(
+                        color: isDark ? Colors.grey[600] : Colors.grey[400],
+                        fontSize: 13,
+                      ),
+                      border: InputBorder.none,
+                      contentPadding: const EdgeInsets.all(16),
+                    ),
+                    style: GoogleFonts.jetBrainsMono(
+                      fontSize: 13,
+                      color: isDark ? Colors.green[300] : Colors.green[800],
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton.icon(
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close, size: 18),
+                  label: const Text('Cancel'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () {
+                    try {
+                      final text = controller.text.trim();
+                      if (text.isEmpty) {
+                        onUpdate(null);
+                      } else {
+                        final parsed = jsonDecode(text);
+                        onUpdate(parsed);
+                      }
+                      Navigator.of(context).pop();
+                    } on Exception catch (e) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Row(
+                            children: [
+                              const Icon(
+                                Icons.error_outline,
+                                color: Colors.white,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(child: Text('Invalid JSON: $e')),
+                            ],
+                          ),
+                          backgroundColor: Colors.red[700],
+                          behavior: SnackBarBehavior.floating,
+                        ),
+                      );
+                    }
+                  },
+                  icon: const Icon(Icons.save, size: 18),
+                  label: const Text('Save'),
+                ),
+              ],
             ),
-          ],
-        ),
-      ),
+          ),
     ).then((_) {
       controller.dispose();
     }),
@@ -860,95 +890,102 @@ void _showAddListItem(
   unawaited(
     showDialog<void>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(Icons.add_circle_outline, color: theme.colorScheme.primary),
-            const SizedBox(width: 8),
-            const Text('Add Array Item'),
-          ],
-        ),
-        content: SizedBox(
-          width: 450,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Enter a JSON value:',
-                style: TextStyle(
-                  color: isDark ? Colors.grey[400] : Colors.grey[700],
+      builder:
+          (context) => AlertDialog(
+            title: Row(
+              children: [
+                Icon(
+                  Icons.add_circle_outline,
+                  color: theme.colorScheme.primary,
                 ),
-              ),
-              const SizedBox(height: 16),
-              Container(
-                decoration: BoxDecoration(
-                  color: isDark ? Colors.grey[850] : Colors.grey[100],
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-                  ),
-                ),
-                child: TextField(
-                  controller: controller,
-                  maxLines: 5,
-                  autofocus: true,
-                  decoration: InputDecoration(
-                    hintText: '"text" or 123 or true or {"key": "value"}',
-                    hintStyle: GoogleFonts.jetBrainsMono(
-                      color: isDark ? Colors.grey[600] : Colors.grey[400],
-                      fontSize: 12,
+                const SizedBox(width: 8),
+                const Text('Add Array Item'),
+              ],
+            ),
+            content: SizedBox(
+              width: 450,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Enter a JSON value:',
+                    style: TextStyle(
+                      color: isDark ? Colors.grey[400] : Colors.grey[700],
                     ),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.all(12),
                   ),
-                  style: GoogleFonts.jetBrainsMono(
-                    fontSize: 13,
-                    color: isDark ? Colors.green[300] : Colors.green[800],
+                  const SizedBox(height: 16),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: isDark ? Colors.grey[850] : Colors.grey[100],
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
+                      ),
+                    ),
+                    child: TextField(
+                      controller: controller,
+                      maxLines: 5,
+                      autofocus: true,
+                      decoration: InputDecoration(
+                        hintText: '"text" or 123 or true or {"key": "value"}',
+                        hintStyle: GoogleFonts.jetBrainsMono(
+                          color: isDark ? Colors.grey[600] : Colors.grey[400],
+                          fontSize: 12,
+                        ),
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.all(12),
+                      ),
+                      style: GoogleFonts.jetBrainsMono(
+                        fontSize: 13,
+                        color: isDark ? Colors.green[300] : Colors.green[800],
+                      ),
+                    ),
                   ),
-                ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton.icon(
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close, size: 18),
+                label: const Text('Cancel'),
+              ),
+              ElevatedButton.icon(
+                onPressed: () {
+                  try {
+                    final text = controller.text.trim();
+                    if (text.isEmpty) {
+                      throw const FormatException('Value cannot be empty');
+                    }
+                    final parsed = jsonDecode(text);
+                    final updatedList = List<dynamic>.from(currentList)
+                      ..add(parsed);
+                    onUpdate(updatedList);
+                    Navigator.of(context).pop();
+                  } on Exception catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Row(
+                          children: [
+                            const Icon(
+                              Icons.error_outline,
+                              color: Colors.white,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(child: Text('Invalid JSON: $e')),
+                          ],
+                        ),
+                        backgroundColor: Colors.red[700],
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
+                  }
+                },
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('Add'),
               ),
             ],
           ),
-        ),
-        actions: [
-          TextButton.icon(
-            onPressed: () => Navigator.of(context).pop(),
-            icon: const Icon(Icons.close, size: 18),
-            label: const Text('Cancel'),
-          ),
-          ElevatedButton.icon(
-            onPressed: () {
-              try {
-                final text = controller.text.trim();
-                if (text.isEmpty) {
-                  throw const FormatException('Value cannot be empty');
-                }
-                final parsed = jsonDecode(text);
-                final updatedList = List<dynamic>.from(currentList)
-                  ..add(parsed);
-                onUpdate(updatedList);
-                Navigator.of(context).pop();
-              } on Exception catch (e) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Row(
-                      children: [
-                        const Icon(Icons.error_outline, color: Colors.white),
-                        const SizedBox(width: 8),
-                        Expanded(child: Text('Invalid JSON: $e')),
-                      ],
-                    ),
-                    backgroundColor: Colors.red[700],
-                    behavior: SnackBarBehavior.floating,
-                  ),
-                );
-              }
-            },
-            icon: const Icon(Icons.add, size: 18),
-            label: const Text('Add'),
-          ),
-        ],
-      ),
     ).then((_) {
       // Dispose controller after dialog is closed
       controller.dispose();
@@ -969,126 +1006,134 @@ void _showAddMapEntry(
   unawaited(
     showDialog<void>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(Icons.add_circle_outline, color: theme.colorScheme.primary),
-            const SizedBox(width: 8),
-            const Text('Add Property'),
-          ],
-        ),
-        content: SizedBox(
-          width: 500,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: isDark ? Colors.grey[850] : Colors.grey[100],
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-                  ),
+      builder:
+          (context) => AlertDialog(
+            title: Row(
+              children: [
+                Icon(
+                  Icons.add_circle_outline,
+                  color: theme.colorScheme.primary,
                 ),
-                child: TextField(
-                  controller: keyController,
-                  autofocus: true,
-                  decoration: InputDecoration(
-                    labelText: 'Property Name',
-                    hintText: 'e.g., userName, age, isActive',
-                    hintStyle: GoogleFonts.jetBrainsMono(
-                      color: isDark ? Colors.grey[600] : Colors.grey[400],
-                      fontSize: 12,
+                const SizedBox(width: 8),
+                const Text('Add Property'),
+              ],
+            ),
+            content: SizedBox(
+              width: 500,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      color: isDark ? Colors.grey[850] : Colors.grey[100],
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
+                      ),
                     ),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.all(12),
+                    child: TextField(
+                      controller: keyController,
+                      autofocus: true,
+                      decoration: InputDecoration(
+                        labelText: 'Property Name',
+                        hintText: 'e.g., userName, age, isActive',
+                        hintStyle: GoogleFonts.jetBrainsMono(
+                          color: isDark ? Colors.grey[600] : Colors.grey[400],
+                          fontSize: 12,
+                        ),
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.all(12),
+                      ),
+                      style: GoogleFonts.jetBrainsMono(
+                        fontSize: 13,
+                        color:
+                            isDark ? Colors.lightBlue[300] : Colors.blue[700],
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ),
-                  style: GoogleFonts.jetBrainsMono(
-                    fontSize: 13,
-                    color: isDark ? Colors.lightBlue[300] : Colors.blue[700],
-                    fontWeight: FontWeight.w600,
+                  const SizedBox(height: 16),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: isDark ? Colors.grey[850] : Colors.grey[100],
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
+                      ),
+                    ),
+                    child: TextField(
+                      controller: valueController,
+                      maxLines: 5,
+                      decoration: InputDecoration(
+                        labelText: 'Value (JSON)',
+                        hintText: '"text" or 123 or true or {"key": "value"}',
+                        hintStyle: GoogleFonts.jetBrainsMono(
+                          color: isDark ? Colors.grey[600] : Colors.grey[400],
+                          fontSize: 12,
+                        ),
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.all(12),
+                      ),
+                      style: GoogleFonts.jetBrainsMono(
+                        fontSize: 13,
+                        color: isDark ? Colors.green[300] : Colors.green[800],
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
-              const SizedBox(height: 16),
-              Container(
-                decoration: BoxDecoration(
-                  color: isDark ? Colors.grey[850] : Colors.grey[100],
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-                  ),
-                ),
-                child: TextField(
-                  controller: valueController,
-                  maxLines: 5,
-                  decoration: InputDecoration(
-                    labelText: 'Value (JSON)',
-                    hintText: '"text" or 123 or true or {"key": "value"}',
-                    hintStyle: GoogleFonts.jetBrainsMono(
-                      color: isDark ? Colors.grey[600] : Colors.grey[400],
-                      fontSize: 12,
-                    ),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.all(12),
-                  ),
-                  style: GoogleFonts.jetBrainsMono(
-                    fontSize: 13,
-                    color: isDark ? Colors.green[300] : Colors.green[800],
-                  ),
-                ),
+            ),
+            actions: [
+              TextButton.icon(
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close, size: 18),
+                label: const Text('Cancel'),
+              ),
+              ElevatedButton.icon(
+                onPressed: () {
+                  try {
+                    final key = keyController.text.trim();
+                    final valueText = valueController.text.trim();
+
+                    if (key.isEmpty) {
+                      throw const FormatException('Key cannot be empty');
+                    }
+                    if (valueText.isEmpty) {
+                      throw const FormatException('Value cannot be empty');
+                    }
+
+                    final parsedValue = jsonDecode(valueText);
+                    final updatedMap = Map<String, dynamic>.from(currentMap);
+                    updatedMap[key] = parsedValue;
+                    onUpdate(updatedMap);
+                    Navigator.of(context).pop();
+                  } on Exception catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Row(
+                          children: [
+                            const Icon(
+                              Icons.error_outline,
+                              color: Colors.white,
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(child: Text('Invalid JSON: $e')),
+                          ],
+                        ),
+                        backgroundColor: Colors.red[700],
+                        behavior: SnackBarBehavior.floating,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                    );
+                  }
+                },
+                icon: const Icon(Icons.check, size: 18),
+                label: const Text('Add'),
               ),
             ],
           ),
-        ),
-        actions: [
-          TextButton.icon(
-            onPressed: () => Navigator.of(context).pop(),
-            icon: const Icon(Icons.close, size: 18),
-            label: const Text('Cancel'),
-          ),
-          ElevatedButton.icon(
-            onPressed: () {
-              try {
-                final key = keyController.text.trim();
-                final valueText = valueController.text.trim();
-
-                if (key.isEmpty) {
-                  throw const FormatException('Key cannot be empty');
-                }
-                if (valueText.isEmpty) {
-                  throw const FormatException('Value cannot be empty');
-                }
-
-                final parsedValue = jsonDecode(valueText);
-                final updatedMap = Map<String, dynamic>.from(currentMap);
-                updatedMap[key] = parsedValue;
-                onUpdate(updatedMap);
-                Navigator.of(context).pop();
-              } on Exception catch (e) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Row(
-                      children: [
-                        const Icon(Icons.error_outline, color: Colors.white),
-                        const SizedBox(width: 8),
-                        Expanded(child: Text('Invalid JSON: $e')),
-                      ],
-                    ),
-                    backgroundColor: Colors.red[700],
-                    behavior: SnackBarBehavior.floating,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                  ),
-                );
-              }
-            },
-            icon: const Icon(Icons.check, size: 18),
-            label: const Text('Add'),
-          ),
-        ],
-      ),
     ).then((_) {
       // Dispose controllers after dialog is closed
       keyController.dispose();

--- a/packages/isar_plus_inspector/lib/object/property_value.dart
+++ b/packages/isar_plus_inspector/lib/object/property_value.dart
@@ -77,48 +77,53 @@ class _EnumValue extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enumName = enumMap.entries
-        .firstWhere(
-          (e) => e.value == value,
-          orElse: () {
-            if (isByte) {
-              return enumMap.entries.first;
-            } else {
-              return const MapEntry('null', null);
-            }
-          },
-        )
-        .key;
+    final enumName =
+        enumMap.entries
+            .firstWhere(
+              (e) => e.value == value,
+              orElse: () {
+                if (isByte) {
+                  return enumMap.entries.first;
+                } else {
+                  return const MapEntry('null', null);
+                }
+              },
+            )
+            .key;
     return GestureDetector(
-      onTapDown: onUpdate == null
-          ? null
-          : (details) async {
-              final nullValue = Object();
-              final newValue = await showMenu(
-                context: context,
-                position: RelativeRect.fromLTRB(
-                  details.globalPosition.dx,
-                  details.globalPosition.dy,
-                  100000,
-                  0,
-                ),
-                items: [
-                  if (!isByte)
-                    PopupMenuItem(value: nullValue, child: const Text('null')),
-                  for (final enumName in enumMap.keys)
-                    PopupMenuItem(
-                      value: enumMap[enumName],
-                      child: Text(enumName),
-                    ),
-                ],
-              );
-
-              if (newValue != null) {
-                onUpdate?.call(
-                  !identical(newValue, nullValue) ? newValue : null,
+      onTapDown:
+          onUpdate == null
+              ? null
+              : (details) async {
+                final nullValue = Object();
+                final newValue = await showMenu(
+                  context: context,
+                  position: RelativeRect.fromLTRB(
+                    details.globalPosition.dx,
+                    details.globalPosition.dy,
+                    100000,
+                    0,
+                  ),
+                  items: [
+                    if (!isByte)
+                      PopupMenuItem(
+                        value: nullValue,
+                        child: const Text('null'),
+                      ),
+                    for (final enumName in enumMap.keys)
+                      PopupMenuItem(
+                        value: enumMap[enumName],
+                        child: Text(enumName),
+                      ),
+                  ],
                 );
-              }
-            },
+
+                if (newValue != null) {
+                  onUpdate?.call(
+                    !identical(newValue, nullValue) ? newValue : null,
+                  );
+                }
+              },
       child: Text(
         enumName,
         style: GoogleFonts.jetBrainsMono(
@@ -139,30 +144,31 @@ class _BoolValue extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTapDown: onUpdate == null
-          ? null
-          : (details) async {
-              const nullValue = Object();
-              final newValue = await showMenu(
-                context: context,
-                position: RelativeRect.fromLTRB(
-                  details.globalPosition.dx,
-                  details.globalPosition.dy,
-                  100000,
-                  0,
-                ),
-                items: const [
-                  PopupMenuItem(value: nullValue, child: Text('null')),
-                  PopupMenuItem(value: true, child: Text('true')),
-                  PopupMenuItem(value: false, child: Text('false')),
-                ],
-              );
-              if (newValue != null) {
-                onUpdate?.call(
-                  !identical(newValue, nullValue) ? newValue : null,
+      onTapDown:
+          onUpdate == null
+              ? null
+              : (details) async {
+                const nullValue = Object();
+                final newValue = await showMenu(
+                  context: context,
+                  position: RelativeRect.fromLTRB(
+                    details.globalPosition.dx,
+                    details.globalPosition.dy,
+                    100000,
+                    0,
+                  ),
+                  items: const [
+                    PopupMenuItem(value: nullValue, child: Text('null')),
+                    PopupMenuItem(value: true, child: Text('true')),
+                    PopupMenuItem(value: false, child: Text('false')),
+                  ],
                 );
-              }
-            },
+                if (newValue != null) {
+                  onUpdate?.call(
+                    !identical(newValue, nullValue) ? newValue : null,
+                  );
+                }
+              },
       child: Text(
         '$value',
         style: GoogleFonts.jetBrainsMono(
@@ -223,23 +229,23 @@ class _DateValue extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final date = value != null
-        ? DateTime.fromMicrosecondsSinceEpoch(value!)
-        : null;
+    final date =
+        value != null ? DateTime.fromMicrosecondsSinceEpoch(value!) : null;
     return GestureDetector(
-      onTap: onUpdate == null
-          ? null
-          : () async {
-              final newDate = await showDatePicker(
-                context: context,
-                initialDate: date ?? DateTime.now(),
-                firstDate: DateTime(1970),
-                lastDate: DateTime(2050),
-              );
-              if (newDate != null) {
-                onUpdate?.call(newDate.microsecondsSinceEpoch);
-              }
-            },
+      onTap:
+          onUpdate == null
+              ? null
+              : () async {
+                final newDate = await showDatePicker(
+                  context: context,
+                  initialDate: date ?? DateTime.now(),
+                  firstDate: DateTime(1970),
+                  lastDate: DateTime(2050),
+                );
+                if (newDate != null) {
+                  onUpdate?.call(newDate.microsecondsSinceEpoch);
+                }
+              },
       child: Text(
         date?.toIso8601String() ?? 'null',
         style: GoogleFonts.jetBrainsMono(
@@ -263,9 +269,10 @@ class _StringValue extends StatefulWidget {
 
 class _StringValueState extends State<_StringValue> {
   late final controller = TextEditingController(
-    text: widget.value != null
-        ? '"${widget.value.toString().replaceAll('\n', '⤵')}"'
-        : '',
+    text:
+        widget.value != null
+            ? '"${widget.value.toString().replaceAll('\n', '⤵')}"'
+            : '',
   );
 
   @override

--- a/packages/isar_plus_inspector/lib/object/property_view.dart
+++ b/packages/isar_plus_inspector/lib/object/property_view.dart
@@ -33,16 +33,17 @@ class PropertyView extends StatelessWidget {
       bold: isId,
       underline: isIndexed,
       type: '${property.type.typeName} $valueLength',
-      value: value is List
-          ? null
-          : property.type.isList
-          ? const NullValue()
-          : PropertyValue(
-              value,
-              type: property.type,
-              enumMap: property.enumMap,
-              onUpdate: isId ? null : onUpdate,
-            ),
+      value:
+          value is List
+              ? null
+              : property.type.isList
+              ? const NullValue()
+              : PropertyValue(
+                value,
+                type: property.type,
+                enumMap: property.enumMap,
+                onUpdate: isId ? null : onUpdate,
+              ),
       children: [
         if (value is List)
           for (var i = 0; i < value.length; i++) _buildListItem(i, value[i]),

--- a/packages/isar_plus_inspector/lib/query_builder/query_group.dart
+++ b/packages/isar_plus_inspector/lib/query_builder/query_group.dart
@@ -15,10 +15,8 @@ class FilterGroup extends FilterOperation {
   @override
   Filter? toIsarFilter() {
     if (filters.isEmpty) return null;
-    final isarFilters = filters
-        .map((e) => e.toIsarFilter())
-        .whereType<Filter>()
-        .toList();
+    final isarFilters =
+        filters.map((e) => e.toIsarFilter()).whereType<Filter>().toList();
     return and ? AndGroup(isarFilters) : OrGroup(isarFilters);
   }
 }
@@ -140,8 +138,9 @@ class QueryGroup extends StatelessWidget {
                           schema: schema,
                           group: filter,
                           level: level + 1,
-                          onChanged: (updated) =>
-                              _performUpdate(add: updated, remove: filter),
+                          onChanged:
+                              (updated) =>
+                                  _performUpdate(add: updated, remove: filter),
                           onDelete: () => _performUpdate(remove: filter),
                         )
                       else
@@ -150,8 +149,11 @@ class QueryGroup extends StatelessWidget {
                             QueryFilter(
                               schema: schema,
                               condition: filter as FilterCondition,
-                              onChanged: (updated) =>
-                                  _performUpdate(add: updated, remove: filter),
+                              onChanged:
+                                  (updated) => _performUpdate(
+                                    add: updated,
+                                    remove: filter,
+                                  ),
                             ),
                             const SizedBox(width: 5),
                             IconButton(

--- a/packages/isar_plus_inspector/pubspec.yaml
+++ b/packages/isar_plus_inspector/pubspec.yaml
@@ -1,14 +1,15 @@
 name: isar_plus_inspector
+resolution: workspace
 publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   clickup_fading_scroll:
     git:
-      url: https://github.com/clickup/clickup_fading_scroll
+      url: https://github.com/clickup/clickup_fading_scroll.git
   flutter:
     sdk: flutter
   flutter_riverpod: ^3.0.3
@@ -16,7 +17,7 @@ dependencies:
   font_awesome_flutter: ^10.12.0
   go_router: ^16.3.0
   google_fonts: ^6.3.2
-  isar_plus: ^1.2.2
+  isar_plus: 0.0.0-placeholder
   vm_service: ^15.0.2
   web: ^1.1.1
   web_socket_channel: ^3.0.3

--- a/packages/isar_plus_test/pubspec.yaml
+++ b/packages/isar_plus_test/pubspec.yaml
@@ -1,4 +1,5 @@
 name: isar_plus_test
+resolution: workspace
 
 publish_to: "none"
 
@@ -21,7 +22,7 @@ dependencies:
   meta: ^1.18.0
   path: ^1.9.1
   path_provider: ^2.1.5
-  test: ^1.31.0
+  test: ">=1.24.0 <2.0.0"
 
 
 dev_dependencies:
@@ -32,9 +33,3 @@ dev_dependencies:
   json_serializable: ^6.14.0
   very_good_analysis: ^10.2.0
 
-
-dependency_overrides:
-  isar_plus:
-    path: ../isar_plus
-  isar_plus_flutter_libs:
-    path: ../isar_plus_flutter_libs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,107 @@
+name: isar_plus_workspace
+publish_to: none
+
+environment:
+  sdk: ">=3.7.0 <4.0.0"
+
+workspace:
+  - packages/isar_plus
+  - packages/isar_plus_flutter_libs
+  - packages/isar_plus_inspector
+  - packages/isar_plus_test
+  - examples/counter
+  - examples/pub
+  - examples/test/isar_embedded_inspector_issue
+
+dev_dependencies:
+  melos: ^7.8.0
+
+melos:
+  scripts:
+    dev:setup:
+      run: bash tool/prepare_local_dev.sh
+      description: "Prepare local dev environment (darwin + wasm by default)"
+    format:
+      run: dart format .
+      description: "Format all Dart code across packages"
+    analyze:
+      run: flutter analyze
+      exec:
+        concurrency: 1
+        failFast: false
+      description: "Run flutter analyze on all packages"
+      packageFilters:
+        scope:
+          - isar_plus
+          - isar_plus_flutter_libs
+          - isar_plus_inspector
+          - isar_plus_test
+    build:native:
+      run: bash tool/build.sh
+      description: "Build native binary for the current platform (arch auto-detected)"
+    build:darwin:
+      run: bash tool/build_darwin.sh
+      description: "Build Darwin XCFramework (macOS + iOS)"
+    build:android:
+      run: bash tool/build_android.sh
+      description: "Build Android shared library (arm64 by default, pass armv7/x64 as arg)"
+    build:wasm:
+      run: bash tool/build_wasm.sh
+      description: "Build WebAssembly bundle (isar_plus.wasm + isar_plus.js)"
+    build:linux:
+      run: bash tool/build_linux.sh x64
+      description: "Build Linux x64 shared object"
+    build:windows:
+      run: bash tool/build_windows.sh x64
+      description: "Build Windows x64 DLL"
+    gen:bindings:
+      run: bash tool/generate_bindings.sh
+      description: "Regenerate Rust→C bindings (cbindgen) and Dart FFI bindings (ffigen)"
+    gen:dart:
+      run: flutter pub run build_runner build --delete-conflicting-outputs
+      exec:
+        concurrency: 1
+      description: "Run Dart code generation (build_runner)"
+      packageFilters:
+        scope:
+          - isar_plus_test
+    test:prepare:
+      run: bash tool/prepare_tests.sh
+      description: "Prepare isar_plus_test (generate test files + build_runner)"
+    test:unit:
+      run: dart test
+      exec:
+        concurrency: 1
+      description: "Run Dart unit tests (isar_plus generator tests)"
+      packageFilters:
+        scope:
+          - isar_plus
+    test:flutter:
+      run: flutter test -j 1
+      exec:
+        concurrency: 1
+      description: "Run Flutter tests in isar_plus_test"
+      packageFilters:
+        scope:
+          - isar_plus_test
+    test:web:
+      run: dart test -p chrome
+      exec:
+        concurrency: 1
+      description: "Run web (Chrome) tests in isar_plus_test"
+      packageFilters:
+        scope:
+          - isar_plus_test
+    test:rust:
+      run: cargo test
+      description: "Run Rust unit tests (cargo test in workspace root)"
+    publish:dry:
+      run: dart pub publish --dry-run
+      exec:
+        concurrency: 1
+      description: "Dry-run pub.dev publish for all public packages"
+      packageFilters:
+        noPrivate: true
+    download:binaries:
+      run: bash tool/download_binaries.sh
+      description: "Download pre-built release binaries (used during pub.dev publish)"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ workspace:
   - packages/isar_plus_test
   - examples/counter
   - examples/pub
-  - examples/test/isar_embedded_inspector_issue
 
 dev_dependencies:
   melos: ^7.8.0


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the repository to a native Dart workspace (`resolution: workspace`) managed by melos, replacing per-package `pubspec_overrides.yaml` files and scattered `pub get` calls in CI. Dart code changes are purely reformatting (new cascade/conditional-expression indentation style from `dart format`).

- Adds a root `pubspec.yaml` defining the workspace with six members and embeds the melos script configuration (bootstrap, analyze, test, build, publish scripts).
- Updates all package `pubspec.yaml` files with `resolution: workspace`, removes `pubspec_overrides.yaml` files, and widens the `test` version constraint to `">=1.24.0 <2.0.0"` for cross-package compatibility.
- Rewrites every CI workflow step that previously ran `pub get` per package or directly invoked tools to instead run `flutter pub get` (workspace root) followed by `dart run melos run <script>`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the workspace migration is mechanical and well-structured, and Dart code changes are formatting-only.

All functional changes are the addition of the Dart workspace root pubspec, melos script configuration, and the corresponding CI rewrites. The Dart source changes are pure dart format reformatting with no logic mutations. The workspace membership list matches the packages present in the repository, and the melos publish command correctly targets only non-private packages.

The root pubspec.yaml is the only file worth a second look, specifically the melos script block.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pubspec.yaml | New root workspace pubspec.yaml defining six workspace members and embedding melos configuration. The gen:dart script uses the deprecated flutter pub run build_runner build command. |
| .github/workflows/test.yaml | CI test workflow refactored to use melos scripts after a single root-level bootstrap step; equivalent behavior to the old per-package pub get sequences. |
| .github/workflows/release.yaml | Release workflow replaced two separate per-package publish steps with a single melos publish --no-dry-run --yes, which correctly targets only non-private packages. |
| packages/isar_plus/pubspec.yaml | Added resolution: workspace; widened test constraint to >=1.24.0 <2.0.0 for workspace-wide resolution compatibility. |
| packages/isar_plus_test/pubspec.yaml | Added resolution: workspace, widened test constraint, and removed dependency_overrides block (now handled by workspace resolution). |
| packages/isar_plus_inspector/lib/object/property_json_value.dart | Pure dart format reformatting of callback and ternary expressions; no logic changes. |
| packages/isar_plus/lib/src/generator/isar_analyzer.dart | Pure dart format reformatting of chained method calls and ternary expressions; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI Job Start] --> B[Bootstrap flutter pub get at workspace root]
    B --> C{Job Type}
    C -->|analyze| D[dart run melos run analyze]
    C -->|unit test| E[dart run melos run test:unit]
    C -->|flutter test| F[dart run melos run test:prepare]
    F --> G[dart run melos run test:flutter]
    C -->|web test| F2[dart run melos run test:prepare]
    F2 --> H[dart run melos run test:web]
    C -->|integration test| F3[dart run melos run test:prepare]
    F3 --> I[flutter drive in isar_plus_test]
    C -->|release| J[dart run melos publish --no-dry-run --yes]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: remove examples/test/isar\_embedde..."](https://github.com/ahmtydn/isar_plus/commit/f5e42c52e24ac2cc9ed4d3a147e8ac43e1dedb03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34709371)</sub>

<!-- /greptile_comment -->